### PR TITLE
fix: allow nightly scan when PR creation is blocked

### DIFF
--- a/.github/workflows/nightly-scan.yml
+++ b/.github/workflows/nightly-scan.yml
@@ -131,6 +131,22 @@ jobs:
             return 1
           }
 
+          emit_manual_pr_summary() {
+            local message="$1"
+            local manual_pr_url="https://github.com/${GITHUB_REPOSITORY}/pull/new/${BRANCH}"
+
+            echo "::warning::${message}"
+            echo "::warning::Open a PR manually: ${manual_pr_url}"
+            {
+              echo "## Nightly scan results pushed"
+              echo ""
+              echo "${message}"
+              echo ""
+              echo "- Branch: \`${BRANCH}\`"
+              echo "- Open PR manually: ${manual_pr_url}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
           # Validate expected scan artifacts exist
           MISSING=()
           for f in "${NIGHTLY_ALLOWED_FILES[@]}"; do
@@ -201,15 +217,39 @@ jobs:
           # Create PR if one doesn't already exist (scoped to this repo, not forks)
           EXISTING_PR=$(gh pr list --head "${{ github.repository_owner }}:$BRANCH" --base "$DEFAULT_BRANCH" --state open --json number --jq '.[0].number // empty')
           if [ -z "$EXISTING_PR" ]; then
-            gh pr create \
+            set +e
+            PR_OUTPUT=$(gh pr create \
               --base "$DEFAULT_BRANCH" \
               --head "$BRANCH" \
               --title "$PR_TITLE" \
-              --body-file /tmp/nightly-pr-body.md
+              --body-file /tmp/nightly-pr-body.md 2>&1)
+            PR_STATUS=$?
+            set -e
+
+            if [ $PR_STATUS -eq 0 ]; then
+              printf '%s\n' "$PR_OUTPUT"
+            elif printf '%s' "$PR_OUTPUT" | grep -F -q 'GitHub Actions is not permitted to create or approve pull requests'; then
+              emit_manual_pr_summary "GitHub Actions could not create a pull request with GITHUB_TOKEN."
+            else
+              printf '%s\n' "$PR_OUTPUT" >&2
+              exit $PR_STATUS
+            fi
           else
-            gh pr edit "$EXISTING_PR" \
+            set +e
+            PR_OUTPUT=$(gh pr edit "$EXISTING_PR" \
               --title "$PR_TITLE" \
-              --body-file /tmp/nightly-pr-body.md
+              --body-file /tmp/nightly-pr-body.md 2>&1)
+            PR_STATUS=$?
+            set -e
+
+            if [ $PR_STATUS -eq 0 ]; then
+              printf '%s\n' "$PR_OUTPUT"
+            elif printf '%s' "$PR_OUTPUT" | grep -F -q 'GitHub Actions is not permitted to create or approve pull requests'; then
+              emit_manual_pr_summary "GitHub Actions could not update PR #${EXISTING_PR} with GITHUB_TOKEN."
+            else
+              printf '%s\n' "$PR_OUTPUT" >&2
+              exit $PR_STATUS
+            fi
           fi
 
       - name: 📤 Upload database artifact

--- a/.github/workflows/nightly-scan.yml
+++ b/.github/workflows/nightly-scan.yml
@@ -133,17 +133,18 @@ jobs:
 
           emit_manual_pr_summary() {
             local message="$1"
-            local manual_pr_url="https://github.com/${GITHUB_REPOSITORY}/pull/new/${BRANCH}"
+            local action_url="${2:-https://github.com/${GITHUB_REPOSITORY}/pull/new/${BRANCH}}"
+            local action_label="${3:-Open PR manually}"
 
             echo "::warning::${message}"
-            echo "::warning::Open a PR manually: ${manual_pr_url}"
+            echo "::warning::${action_label}: ${action_url}"
             {
               echo "## Nightly scan results pushed"
               echo ""
               echo "${message}"
               echo ""
               echo "- Branch: \`${BRANCH}\`"
-              echo "- Open PR manually: ${manual_pr_url}"
+              echo "- ${action_label}: ${action_url}"
             } >> "$GITHUB_STEP_SUMMARY"
           }
 
@@ -245,7 +246,10 @@ jobs:
             if [ $PR_STATUS -eq 0 ]; then
               printf '%s\n' "$PR_OUTPUT"
             elif printf '%s' "$PR_OUTPUT" | grep -F -q 'GitHub Actions is not permitted to create or approve pull requests'; then
-              emit_manual_pr_summary "GitHub Actions could not update PR #${EXISTING_PR} with GITHUB_TOKEN."
+              emit_manual_pr_summary \
+                "GitHub Actions could not update PR #${EXISTING_PR} with GITHUB_TOKEN." \
+                "https://github.com/${GITHUB_REPOSITORY}/pull/${EXISTING_PR}" \
+                "Review existing PR manually"
             else
               printf '%s\n' "$PR_OUTPUT" >&2
               exit $PR_STATUS


### PR DESCRIPTION
## Summary

Handle the repository limitation where GitHub Actions can push the nightly results branch with `GITHUB_TOKEN` but cannot create or update pull requests.

Relates to #6

## Changes

- keep pushing `nightly-scan-results` as before
- attempt to create or update the PR
- if GitHub blocks that action, emit a manual PR link in the workflow summary instead of failing the nightly run
- preserve existing behavior for unexpected `gh pr` failures by still failing the job

## Why

The latest nightly run failed after successfully pushing the results branch with:

> `GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)`

This change keeps the nightly scan usable until a GitHub App or different permission model is available.
