### PR TITLE
docs: note nightly scan manual PR workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Every night, this project scans configured MCR (Microsoft Container Registry) co
 | Markdown | [docs/daily_recommendations.md](docs/daily_recommendations.md)     |
 | JSON     | [docs/daily_recommendations.json](docs/daily_recommendations.json) |
 
-Reports are regenerated nightly at 02:00 UTC via [GitHub Actions](.github/workflows/nightly-scan.yml) and committed automatically. Images are ranked per language by: fewest critical → fewest high → fewest total vulnerabilities → smallest size.
+Reports are regenerated nightly at 02:00 UTC via [GitHub Actions](.github/workflows/nightly-scan.yml). Images are ranked per language by: fewest critical → fewest high → fewest total vulnerabilities → smallest size.
+
+> **Note:** The nightly workflow currently pushes results to the `nightly-scan-results` branch and requires a manual PR to merge into `main`, because GitHub Actions on this repository cannot create pull requests automatically. See [#6](https://github.com/microsoft/sbi/issues/6) for details and the planned migration to a GitHub App token.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

Documents the current nightly scan limitation where GitHub Actions cannot create PRs automatically on this repository.

### Changes
- Removed misleading "committed automatically" wording from the Daily Reports section
- Added a note explaining the current workaround: results are pushed to the `nightly-scan-results` branch and require a manual PR
- Links to #6 for full context on the planned GitHub App token migration

Relates to #6