### PR TITLE
feat: add issue templates, PR template, and issue config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-issue-forms.json
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+---
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: version
+    attributes:
+      label: Version
+      description: What version of SBI are you running? Include OS/distribution and Go version.
+      placeholder: |
+        sbi version: (output of `sbi --version` or commit SHA)
+        OS: macOS 15 / Ubuntu 24.04 / etc.
+        Go: 1.26
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug and what you expected to happen instead.
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Please provide the exact command and flags used.
+      placeholder: |
+        1. Run `sbi scan --config-dir config --database test.db ...`
+        2. Observe error in output
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. Run with `--verbose` for detailed logs. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: If relevant, paste your repositories.json or describe the image(s) being scanned.
+      render: json

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-issue-config.json
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+---
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerabilities
+    url: https://aka.ms/SECURITY.md
+    about: Please report security vulnerabilities through the Microsoft Security Response Center, not GitHub Issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-issue-forms.json
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+---
+name: Feature Request
+description: Suggest a new feature or improvement.
+labels: [enhancement]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the feature you would like to see.
+      placeholder: Please describe the feature or improvement.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: How would this feature help you? What problem does it solve?
+      placeholder: Describe your use case.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+
+<!-- Brief description of the changes -->
+
+## Related Issue
+
+<!-- Link to the issue this PR addresses, e.g., Fixes #123 -->
+
+## Changes
+
+<!-- List the key changes made -->
+
+-
+
+## Checklist
+
+- [ ] `task lint` passes locally
+- [ ] `task test` passes locally
+- [ ] Documentation updated (if applicable)


### PR DESCRIPTION
## Description

Add structured GitHub issue forms and a PR template to improve the community profile and standardize contributions.

Fixes #30

## Changes

- **Bug report form** (`.github/ISSUE_TEMPLATE/bug_report.yaml`) — structured form with SBI-specific fields: version/OS/Go, description, reproduction steps, verbose log output, and repositories.json config
- **Feature request form** (`.github/ISSUE_TEMPLATE/feature_request.yaml`) — description + use-case fields
- **Issue chooser config** (`.github/ISSUE_TEMPLATE/config.yaml`) — disables blank issues, adds security reporting link to MSRC
- **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`) — checklist for lint, test, and docs

Templates are modeled after [Azure/mpf](https://github.com/Azure/mpf) and tailored for SBI's CLI workflow.

## Checklist

- [x] `task lint` passes locally (YAML lint clean; markdown lint failures are in unrelated session files)
- [x] No code changes — templates only
- [x] Documentation updated (N/A)