### PR TITLE
feat: deduplicate ranking table entries sharing the same image digest

### DIFF
--- a/pkg/domain/models.go
+++ b/pkg/domain/models.go
@@ -229,4 +229,5 @@ type RecommendedImage struct {
 	CreatedDate             string
 	Digest                  string
 	BaseOSName              string
+	AlternateTags           []string
 }

--- a/pkg/infrastructure/report/dedup.go
+++ b/pkg/infrastructure/report/dedup.go
@@ -1,0 +1,127 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package report
+
+import (
+	"strings"
+
+	"github.com/microsoft/sbi/pkg/domain"
+)
+
+// DeduplicateByDigest groups images sharing the same digest, keeping the most
+// specific tag as the primary entry and collecting alternate tag names.
+// Images with an empty digest are never grouped.
+func DeduplicateByDigest(images []domain.RecommendedImage) []domain.RecommendedImage {
+	if len(images) <= 1 {
+		return images
+	}
+
+	type group struct {
+		primary int
+		indices []int
+	}
+
+	// Ordered list of groups preserving first-seen order.
+	var groups []group
+	// Maps non-empty digest to index in groups slice.
+	byDigest := make(map[string]int)
+
+	for i, img := range images {
+		d := img.Digest
+		if d == "" {
+			groups = append(groups, group{primary: i, indices: []int{i}})
+			continue
+		}
+
+		if gi, ok := byDigest[d]; ok {
+			groups[gi].indices = append(groups[gi].indices, i)
+			if tagSpecificity(images[i].Name) > tagSpecificity(images[groups[gi].primary].Name) {
+				groups[gi].primary = i
+			}
+		} else {
+			byDigest[d] = len(groups)
+			groups = append(groups, group{primary: i, indices: []int{i}})
+		}
+	}
+
+	result := make([]domain.RecommendedImage, 0, len(groups))
+	for _, g := range groups {
+		img := images[g.primary]
+		img.AlternateTags = nil
+
+		for _, idx := range g.indices {
+			if idx == g.primary {
+				continue
+			}
+			alt := extractTag(images[idx].Name)
+			if alt != "" {
+				img.AlternateTags = append(img.AlternateTags, ":"+alt)
+			}
+		}
+
+		result = append(result, img)
+	}
+
+	return result
+}
+
+// tagSpecificity scores how specific an image tag is.
+// Higher score = more specific. Prefers numeric version tags over
+// non-numeric ones, then counts dot-separated version segments.
+func tagSpecificity(name string) int {
+	tag := extractTag(name)
+	if tag == "" {
+		return 0
+	}
+
+	// Tags starting with a digit are strongly preferred over non-numeric tags
+	// (e.g., "3.12" should always beat "latest").
+	numericBonus := 0
+	if len(tag) > 0 && tag[0] >= '0' && tag[0] <= '9' {
+		numericBonus = 10000
+	}
+
+	// Extract the leading version portion (before any '-' suffix like "-nonroot").
+	versionPart := tag
+	if idx := strings.IndexByte(tag, '-'); idx > 0 {
+		versionPart = tag[:idx]
+	}
+
+	segments := strings.Count(versionPart, ".") + 1
+
+	// Use numericBonus + segments * 1000 + tag length for tie-breaking.
+	return numericBonus + segments*1000 + len(tag)
+}
+
+// extractTag returns the tag portion of a full image name.
+// E.g., "mcr.microsoft.com/repo:3.12-nonroot" → "3.12-nonroot"
+func extractTag(name string) string {
+	lastSlash := strings.LastIndex(name, "/")
+	lastColon := strings.LastIndex(name, ":")
+
+	if lastColon > lastSlash {
+		return name[lastColon+1:]
+	}
+
+	return ""
+}

--- a/pkg/infrastructure/report/dedup.go
+++ b/pkg/infrastructure/report/dedup.go
@@ -23,6 +23,7 @@
 package report
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/microsoft/sbi/pkg/domain"
@@ -55,7 +56,9 @@ func DeduplicateByDigest(images []domain.RecommendedImage) []domain.RecommendedI
 
 		if gi, ok := byDigest[d]; ok {
 			groups[gi].indices = append(groups[gi].indices, i)
-			if tagSpecificity(images[i].Name) > tagSpecificity(images[groups[gi].primary].Name) {
+			newScore := tagSpecificity(images[i].Name)
+			oldScore := tagSpecificity(images[groups[gi].primary].Name)
+			if newScore > oldScore || (newScore == oldScore && images[i].Name < images[groups[gi].primary].Name) {
 				groups[gi].primary = i
 			}
 		} else {
@@ -78,6 +81,7 @@ func DeduplicateByDigest(images []domain.RecommendedImage) []domain.RecommendedI
 				img.AlternateTags = append(img.AlternateTags, ":"+alt)
 			}
 		}
+		sort.Strings(img.AlternateTags)
 
 		result = append(result, img)
 	}
@@ -115,7 +119,13 @@ func tagSpecificity(name string) int {
 
 // extractTag returns the tag portion of a full image name.
 // E.g., "mcr.microsoft.com/repo:3.12-nonroot" → "3.12-nonroot"
+// Strips any @sha256:... digest suffix before parsing.
 func extractTag(name string) string {
+	// Strip @digest suffix if present (e.g., "repo:3.12@sha256:abc..." → "repo:3.12").
+	if at := strings.Index(name, "@"); at >= 0 {
+		name = name[:at]
+	}
+
 	lastSlash := strings.LastIndex(name, "/")
 	lastColon := strings.LastIndex(name, ":")
 

--- a/pkg/infrastructure/report/dedup.go
+++ b/pkg/infrastructure/report/dedup.go
@@ -29,8 +29,10 @@ import (
 	"github.com/microsoft/sbi/pkg/domain"
 )
 
-// DeduplicateByDigest groups images sharing the same digest, keeping the most
-// specific tag as the primary entry and collecting alternate tag names.
+// DeduplicateByDigest groups images sharing the same repository and digest,
+// keeping the most specific tag as the primary entry and collecting alternate
+// tag names. Only images from the same repository are grouped; different
+// repositories with the same digest remain separate entries.
 // Images with an empty digest are never grouped.
 func DeduplicateByDigest(images []domain.RecommendedImage) []domain.RecommendedImage {
 	if len(images) <= 1 {
@@ -44,8 +46,8 @@ func DeduplicateByDigest(images []domain.RecommendedImage) []domain.RecommendedI
 
 	// Ordered list of groups preserving first-seen order.
 	var groups []group
-	// Maps non-empty digest to index in groups slice.
-	byDigest := make(map[string]int)
+	// Maps "repo\x00digest" to index in groups slice.
+	byKey := make(map[string]int)
 
 	for i, img := range images {
 		d := img.Digest
@@ -54,7 +56,8 @@ func DeduplicateByDigest(images []domain.RecommendedImage) []domain.RecommendedI
 			continue
 		}
 
-		if gi, ok := byDigest[d]; ok {
+		key := imageRepo(img.Name) + "\x00" + d
+		if gi, ok := byKey[key]; ok {
 			groups[gi].indices = append(groups[gi].indices, i)
 			newScore := tagSpecificity(images[i].Name)
 			oldScore := tagSpecificity(images[groups[gi].primary].Name)
@@ -62,7 +65,7 @@ func DeduplicateByDigest(images []domain.RecommendedImage) []domain.RecommendedI
 				groups[gi].primary = i
 			}
 		} else {
-			byDigest[d] = len(groups)
+			byKey[key] = len(groups)
 			groups = append(groups, group{primary: i, indices: []int{i}})
 		}
 	}
@@ -134,4 +137,22 @@ func extractTag(name string) string {
 	}
 
 	return ""
+}
+
+// imageRepo returns the repository portion of a full image name (everything
+// before the tag or digest). E.g., "mcr.microsoft.com/repo:3.12" → "mcr.microsoft.com/repo"
+func imageRepo(name string) string {
+	// Strip @digest suffix first.
+	if at := strings.Index(name, "@"); at >= 0 {
+		name = name[:at]
+	}
+
+	lastSlash := strings.LastIndex(name, "/")
+	lastColon := strings.LastIndex(name, ":")
+
+	if lastColon > lastSlash {
+		return name[:lastColon]
+	}
+
+	return name
 }

--- a/pkg/infrastructure/report/dedup_test.go
+++ b/pkg/infrastructure/report/dedup_test.go
@@ -1,0 +1,220 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package report
+
+import (
+	"testing"
+
+	"github.com/microsoft/sbi/pkg/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeduplicateByDigest_TwoSameDigest(t *testing.T) {
+	images := []domain.RecommendedImage{
+		{Name: "mcr.microsoft.com/repo:3", Digest: "sha256:aaa", Version: "3.12.9"},
+		{Name: "mcr.microsoft.com/repo:3.12", Digest: "sha256:aaa", Version: "3.12.9"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "mcr.microsoft.com/repo:3.12", result[0].Name, "most specific tag should win")
+	assert.Equal(t, []string{":3"}, result[0].AlternateTags)
+}
+
+func TestDeduplicateByDigest_ThreeSameDigest(t *testing.T) {
+	images := []domain.RecommendedImage{
+		{Name: "mcr.microsoft.com/repo:24", Digest: "sha256:bbb"},
+		{Name: "mcr.microsoft.com/repo:24.14", Digest: "sha256:bbb"},
+		{Name: "mcr.microsoft.com/repo:24.14.1", Digest: "sha256:bbb"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "mcr.microsoft.com/repo:24.14.1", result[0].Name, "most specific tag should win")
+	assert.Len(t, result[0].AlternateTags, 2)
+	assert.Contains(t, result[0].AlternateTags, ":24")
+	assert.Contains(t, result[0].AlternateTags, ":24.14")
+}
+
+func TestDeduplicateByDigest_NoDuplicates(t *testing.T) {
+	images := []domain.RecommendedImage{
+		{Name: "mcr.microsoft.com/repo:3.12", Digest: "sha256:aaa"},
+		{Name: "mcr.microsoft.com/repo:3.11", Digest: "sha256:bbb"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 2)
+	assert.Nil(t, result[0].AlternateTags)
+	assert.Nil(t, result[1].AlternateTags)
+}
+
+func TestDeduplicateByDigest_EmptyDigestPreservesOrder(t *testing.T) {
+	images := []domain.RecommendedImage{
+		{Name: "emptyA:1", Digest: ""},
+		{Name: "real:2", Digest: "sha256:xxx"},
+		{Name: "emptyB:3", Digest: ""},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 3)
+	assert.Equal(t, "emptyA:1", result[0].Name)
+	assert.Equal(t, "real:2", result[1].Name)
+	assert.Equal(t, "emptyB:3", result[2].Name)
+}
+
+func TestDeduplicateByDigest_LatestVsNumericTag(t *testing.T) {
+	images := []domain.RecommendedImage{
+		{Name: "mcr.microsoft.com/repo:latest", Digest: "sha256:aaa"},
+		{Name: "mcr.microsoft.com/repo:3", Digest: "sha256:aaa"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "mcr.microsoft.com/repo:3", result[0].Name, "numeric tag should win over latest")
+	assert.Equal(t, []string{":latest"}, result[0].AlternateTags)
+}
+
+func TestDeduplicateByDigest_PrimaryAppearsLater(t *testing.T) {
+	// The more specific tag appears second; group should still use first-seen position.
+	images := []domain.RecommendedImage{
+		{Name: "mcr.microsoft.com/repo:3", Digest: "sha256:aaa", Version: "3.12.9"},
+		{Name: "other:1.0", Digest: "sha256:bbb"},
+		{Name: "mcr.microsoft.com/repo:3.12", Digest: "sha256:aaa", Version: "3.12.9"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 2)
+	// The deduped group should appear at position 0 (first-seen order).
+	assert.Equal(t, "mcr.microsoft.com/repo:3.12", result[0].Name)
+	assert.Equal(t, "other:1.0", result[1].Name)
+}
+
+func TestDeduplicateByDigest_MixedDuplicatesAndUnique(t *testing.T) {
+	images := []domain.RecommendedImage{
+		{Name: "mcr.microsoft.com/python:3", Digest: "sha256:aaa"},
+		{Name: "mcr.microsoft.com/python:3.12", Digest: "sha256:aaa"},
+		{Name: "mcr.microsoft.com/node:24", Digest: "sha256:bbb"},
+		{Name: "mcr.microsoft.com/go:1.21", Digest: "sha256:ccc"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 3)
+	assert.Equal(t, "mcr.microsoft.com/python:3.12", result[0].Name)
+	assert.Equal(t, []string{":3"}, result[0].AlternateTags)
+	assert.Equal(t, "mcr.microsoft.com/node:24", result[1].Name)
+	assert.Nil(t, result[1].AlternateTags)
+	assert.Equal(t, "mcr.microsoft.com/go:1.21", result[2].Name)
+	assert.Nil(t, result[2].AlternateTags)
+}
+
+func TestDeduplicateByDigest_SingleImage(t *testing.T) {
+	images := []domain.RecommendedImage{
+		{Name: "mcr.microsoft.com/repo:3.12", Digest: "sha256:aaa"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 1)
+	assert.Nil(t, result[0].AlternateTags)
+}
+
+func TestDeduplicateByDigest_EmptySlice(t *testing.T) {
+	result := DeduplicateByDigest(nil)
+	assert.Nil(t, result)
+
+	result = DeduplicateByDigest([]domain.RecommendedImage{})
+	assert.Empty(t, result)
+}
+
+func TestDeduplicateByDigest_NonrootSuffix(t *testing.T) {
+	images := []domain.RecommendedImage{
+		{Name: "mcr.microsoft.com/repo:24-nonroot", Digest: "sha256:aaa"},
+		{Name: "mcr.microsoft.com/repo:24.14-nonroot", Digest: "sha256:aaa"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "mcr.microsoft.com/repo:24.14-nonroot", result[0].Name, "more version segments should win")
+	assert.Equal(t, []string{":24-nonroot"}, result[0].AlternateTags)
+}
+
+func TestDeduplicateByDigest_PreservesOrder(t *testing.T) {
+	images := []domain.RecommendedImage{
+		{Name: "first:1.0", Digest: "sha256:aaa"},
+		{Name: "second:2.0", Digest: "sha256:bbb"},
+		{Name: "third:3.0", Digest: "sha256:ccc"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 3)
+	assert.Equal(t, "first:1.0", result[0].Name)
+	assert.Equal(t, "second:2.0", result[1].Name)
+	assert.Equal(t, "third:3.0", result[2].Name)
+}
+
+func TestTagSpecificity(t *testing.T) {
+	tests := []struct {
+		name     string
+		less     string
+		more     string
+	}{
+		{"major vs major.minor", "mcr.microsoft.com/repo:3", "mcr.microsoft.com/repo:3.12"},
+		{"major.minor vs major.minor.patch", "mcr.microsoft.com/repo:24.14", "mcr.microsoft.com/repo:24.14.1"},
+		{"with suffix", "mcr.microsoft.com/repo:24-nonroot", "mcr.microsoft.com/repo:24.14-nonroot"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Greater(t, tagSpecificity(tt.more), tagSpecificity(tt.less))
+		})
+	}
+}
+
+func TestExtractTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"with tag", "mcr.microsoft.com/repo:3.12", "3.12"},
+		{"with tag and suffix", "mcr.microsoft.com/repo:3.12-nonroot", "3.12-nonroot"},
+		{"no tag", "mcr.microsoft.com/repo", ""},
+		{"port in name", "localhost:5000/repo:latest", "latest"},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractTag(tt.input))
+		})
+	}
+}

--- a/pkg/infrastructure/report/dedup_test.go
+++ b/pkg/infrastructure/report/dedup_test.go
@@ -209,6 +209,8 @@ func TestExtractTag(t *testing.T) {
 		{"with tag and suffix", "mcr.microsoft.com/repo:3.12-nonroot", "3.12-nonroot"},
 		{"no tag", "mcr.microsoft.com/repo", ""},
 		{"port in name", "localhost:5000/repo:latest", "latest"},
+		{"with digest suffix", "mcr.microsoft.com/repo:3.12@sha256:abcdef", "3.12"},
+		{"digest only no tag", "mcr.microsoft.com/repo@sha256:abcdef", ""},
 		{"empty", "", ""},
 	}
 
@@ -217,4 +219,20 @@ func TestExtractTag(t *testing.T) {
 			assert.Equal(t, tt.expected, extractTag(tt.input))
 		})
 	}
+}
+
+func TestDeduplicateByDigest_DeterministicTieBreak(t *testing.T) {
+	// When two tags have the same specificity score, the lexicographically
+	// smaller name should be chosen as primary for determinism.
+	// "zeta" and "beta" have the same length and structure, so scores are equal.
+	images := []domain.RecommendedImage{
+		{Name: "mcr.microsoft.com/repo:zeta", Digest: "sha256:aaa"},
+		{Name: "mcr.microsoft.com/repo:beta", Digest: "sha256:aaa"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "mcr.microsoft.com/repo:beta", result[0].Name, "lexicographically smaller name should win on tie")
+	assert.Equal(t, []string{":zeta"}, result[0].AlternateTags)
 }

--- a/pkg/infrastructure/report/dedup_test.go
+++ b/pkg/infrastructure/report/dedup_test.go
@@ -236,3 +236,40 @@ func TestDeduplicateByDigest_DeterministicTieBreak(t *testing.T) {
 	assert.Equal(t, "mcr.microsoft.com/repo:beta", result[0].Name, "lexicographically smaller name should win on tie")
 	assert.Equal(t, []string{":zeta"}, result[0].AlternateTags)
 }
+
+func TestDeduplicateByDigest_CrossRepoSameDigestNotMerged(t *testing.T) {
+	// Images from different repositories with the same digest should NOT be merged.
+	images := []domain.RecommendedImage{
+		{Name: "mcr.microsoft.com/azurelinux/base/python:3.12", Digest: "sha256:same"},
+		{Name: "mcr.microsoft.com/azurelinux/base/nodejs:24", Digest: "sha256:same"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 2, "different repos with same digest should remain separate")
+	assert.Equal(t, "mcr.microsoft.com/azurelinux/base/python:3.12", result[0].Name)
+	assert.Equal(t, "mcr.microsoft.com/azurelinux/base/nodejs:24", result[1].Name)
+	assert.Nil(t, result[0].AlternateTags)
+	assert.Nil(t, result[1].AlternateTags)
+}
+
+func TestImageRepo(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"with tag", "mcr.microsoft.com/repo:3.12", "mcr.microsoft.com/repo"},
+		{"with tag and suffix", "mcr.microsoft.com/repo:3.12-nonroot", "mcr.microsoft.com/repo"},
+		{"no tag", "mcr.microsoft.com/repo", "mcr.microsoft.com/repo"},
+		{"with digest", "mcr.microsoft.com/repo:3.12@sha256:abc", "mcr.microsoft.com/repo"},
+		{"digest only", "mcr.microsoft.com/repo@sha256:abc", "mcr.microsoft.com/repo"},
+		{"nested path", "mcr.microsoft.com/azurelinux/base/python:3.12", "mcr.microsoft.com/azurelinux/base/python"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, imageRepo(tt.input))
+		})
+	}
+}

--- a/pkg/infrastructure/report/json.go
+++ b/pkg/infrastructure/report/json.go
@@ -51,21 +51,22 @@ type JSONRepoGroup struct {
 
 // JSONImageEntry represents a single recommended image in the JSON report.
 type JSONImageEntry struct {
-	Rank                    int    `json:"rank"`
-	Language                string `json:"language"`
-	BaseOS                  string `json:"baseOS"`
-	Name                    string `json:"name"`
-	Version                 string `json:"version"`
-	CriticalVulnerabilities int    `json:"criticalVulnerabilities"`
-	HighVulnerabilities     int    `json:"highVulnerabilities"`
-	TotalVulnerabilities    int    `json:"totalVulnerabilities"`
-	SizeBytes               int64  `json:"sizeBytes"`
-	SizeHuman               string `json:"sizeHuman"`
-	CreatedDate             string `json:"createdDate"`
-	Digest                  string `json:"digest"`
-	PinnedReference         string `json:"pinnedReference,omitempty"`
-	StableTag               string `json:"stableTag,omitempty"`
-	DockerfileFrom          string `json:"dockerfileFrom,omitempty"`
+	Rank                    int      `json:"rank"`
+	Language                string   `json:"language"`
+	BaseOS                  string   `json:"baseOS"`
+	Name                    string   `json:"name"`
+	Version                 string   `json:"version"`
+	CriticalVulnerabilities int      `json:"criticalVulnerabilities"`
+	HighVulnerabilities     int      `json:"highVulnerabilities"`
+	TotalVulnerabilities    int      `json:"totalVulnerabilities"`
+	SizeBytes               int64    `json:"sizeBytes"`
+	SizeHuman               string   `json:"sizeHuman"`
+	CreatedDate             string   `json:"createdDate"`
+	Digest                  string   `json:"digest"`
+	PinnedReference         string   `json:"pinnedReference,omitempty"`
+	StableTag               string   `json:"stableTag,omitempty"`
+	DockerfileFrom          string   `json:"dockerfileFrom,omitempty"`
+	AlternateTags           []string `json:"alternateTags,omitempty"`
 }
 
 // GenerateJSONReport produces a flat JSON recommendations report from the database.
@@ -103,10 +104,15 @@ func GenerateJSONReport(repo *database.Repository, outputPath string, topN int, 
 		}
 
 		for _, osName := range oses {
-			images, err := repo.QueryTopImagesByOS(lang, osName, topN)
+			images, err := repo.QueryTopImagesByOS(lang, osName, 0)
 			if err != nil {
 				log.Warnf("Failed to query images for %s/%s: %v", lang, osName, err)
 				continue
+			}
+
+			images = DeduplicateByDigest(images)
+			if topN > 0 && len(images) > topN {
+				images = images[:topN]
 			}
 
 			for idx, img := range images {
@@ -126,6 +132,7 @@ func GenerateJSONReport(repo *database.Repository, outputPath string, topN int, 
 					PinnedReference:         FormatPinnedReference(img.Name, img.Digest),
 					StableTag:               FormatStableTag(img.Name, img.Version),
 					DockerfileFrom:          FormatDockerfileFrom(img.Name, img.Digest),
+					AlternateTags:           img.AlternateTags,
 				})
 			}
 		}

--- a/pkg/infrastructure/report/json_test.go
+++ b/pkg/infrastructure/report/json_test.go
@@ -371,9 +371,9 @@ func TestGenerateMarkdownReport_BaseLanguageSection(t *testing.T) {
 
 	// Base section should contain the base image
 	assert.Contains(t, content, "base-core:3.0")
-	assert.Contains(t, content, "| Rank | Image | Version | Crit | High | Total | Size | Created | Digest | Pinned Reference |")
+	assert.Contains(t, content, "| Rank | Image | Version | Also Tagged As | Crit | High | Total | Size | Created | Digest | Pinned Reference |")
 	assert.Contains(t, content, "2025-04-15")
-	assert.Contains(t, content, "| 1 | `python-img:3.12` | 3.12 | 0 | 0 | 3 | - | - | `` | `-` |")
+	assert.Contains(t, content, "| 1 | `python-img:3.12` | 3.12 | - | 0 | 0 | 3 | - | - | `` | `-` |")
 }
 
 func TestDisplayLanguageName(t *testing.T) {

--- a/pkg/infrastructure/report/json_test.go
+++ b/pkg/infrastructure/report/json_test.go
@@ -394,3 +394,82 @@ func TestDisplayLanguageName(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateJSONReport_DeduplicatesAlternateTags(t *testing.T) {
+	db, repo := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	images := []domain.ImageRecord{
+		{
+			Name: "mcr.microsoft.com/azurelinux/base/nodejs:24", Registry: "mcr.microsoft.com",
+			Repository: "azurelinux/base/nodejs", Tag: "24",
+			BaseOSName: "azurelinux", Digest: "sha256:samedigest",
+			SizeBytes: 100000000, TotalVulnerabilities: 1,
+			Languages: []domain.Language{{Language: "node", Version: "24.14.0"}},
+		},
+		{
+			Name: "mcr.microsoft.com/azurelinux/base/nodejs:24.14", Registry: "mcr.microsoft.com",
+			Repository: "azurelinux/base/nodejs", Tag: "24.14",
+			BaseOSName: "azurelinux", Digest: "sha256:samedigest",
+			SizeBytes: 100000000, TotalVulnerabilities: 1,
+			Languages: []domain.Language{{Language: "node", Version: "24.14.0"}},
+		},
+	}
+
+	for i := range images {
+		require.NoError(t, repo.InsertImage(&images[i]))
+	}
+
+	outPath := filepath.Join(t.TempDir(), "report.json")
+	require.NoError(t, GenerateJSONReport(repo, outPath, 10, nil))
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	var report JSONReport
+	require.NoError(t, json.Unmarshal(data, &report))
+
+	require.Len(t, report.Images, 1, "duplicate digests should be merged into one entry")
+	assert.Equal(t, "mcr.microsoft.com/azurelinux/base/nodejs:24.14", report.Images[0].Name)
+	require.Len(t, report.Images[0].AlternateTags, 1)
+	assert.Equal(t, ":24", report.Images[0].AlternateTags[0])
+}
+
+func TestGenerateMarkdownReport_DeduplicatesWithAlternateColumn(t *testing.T) {
+	db, repo := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	images := []domain.ImageRecord{
+		{
+			Name: "mcr.microsoft.com/azurelinux/base/python:3", Registry: "mcr.microsoft.com",
+			Repository: "azurelinux/base/python", Tag: "3",
+			BaseOSName: "azurelinux", Digest: "sha256:pydigest",
+			SizeBytes: 85000000, TotalVulnerabilities: 2,
+			Languages: []domain.Language{{Language: "python", Version: "3.12.9"}},
+		},
+		{
+			Name: "mcr.microsoft.com/azurelinux/base/python:3.12", Registry: "mcr.microsoft.com",
+			Repository: "azurelinux/base/python", Tag: "3.12",
+			BaseOSName: "azurelinux", Digest: "sha256:pydigest",
+			SizeBytes: 85000000, TotalVulnerabilities: 2,
+			Languages: []domain.Language{{Language: "python", Version: "3.12.9"}},
+		},
+	}
+
+	for i := range images {
+		require.NoError(t, repo.InsertImage(&images[i]))
+	}
+
+	outPath := filepath.Join(t.TempDir(), "report.md")
+	require.NoError(t, GenerateReport(repo, outPath, 10, nil))
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	content := string(data)
+
+	// Should have only one data row (deduped), not two
+	assert.Contains(t, content, "`mcr.microsoft.com/azurelinux/base/python:3.12`")
+	assert.Contains(t, content, "| :3 |", "alternate tag should appear in Also Tagged As column")
+	// Only one ranked row should exist (rank 1, no rank 2)
+	assert.NotContains(t, content, "| 2 | `mcr", "should have only one image row after dedup")
+}

--- a/pkg/infrastructure/report/markdown.go
+++ b/pkg/infrastructure/report/markdown.go
@@ -77,10 +77,15 @@ func GenerateReport(repo *database.Repository, outputPath string, topN int, repo
 				osName = oses[0]
 			}
 
-			images, err := repo.QueryTopImagesByOS(lang, osName, topN)
+			images, err := repo.QueryTopImagesByOS(lang, osName, 0)
 			if err != nil {
 				log.Warnf("Failed to query images for %s: %v", lang, err)
 				continue
+			}
+
+			images = DeduplicateByDigest(images)
+			if topN > 0 && len(images) > topN {
+				images = images[:topN]
 			}
 
 			if len(images) > 0 {
@@ -88,10 +93,15 @@ func GenerateReport(repo *database.Repository, outputPath string, topN int, repo
 			}
 		} else {
 			for _, osName := range oses {
-				osImages, err := repo.QueryTopImagesByOS(lang, osName, topN)
+				osImages, err := repo.QueryTopImagesByOS(lang, osName, 0)
 				if err != nil {
 					log.Warnf("Failed to query images for %s/%s: %v", lang, osName, err)
 					continue
+				}
+
+				osImages = DeduplicateByDigest(osImages)
+				if topN > 0 && len(osImages) > topN {
+					osImages = osImages[:topN]
 				}
 
 				if len(osImages) == 0 {
@@ -126,8 +136,8 @@ func GenerateReport(repo *database.Repository, outputPath string, topN int, repo
 
 // writeImageTable writes a ranked markdown table of images.
 func writeImageTable(sb *strings.Builder, images []domain.RecommendedImage) {
-	sb.WriteString("| Rank | Image | Version | Crit | High | Total | Size | Created | Digest | Pinned Reference |\n")
-	sb.WriteString("|------|-------|---------|------|------|-------|------|---------|--------|------------------|\n")
+	sb.WriteString("| Rank | Image | Version | Also Tagged As | Crit | High | Total | Size | Created | Digest | Pinned Reference |\n")
+	sb.WriteString("|------|-------|---------|----------------|------|------|-------|------|---------|--------|------------------|\n")
 
 	for idx, img := range images {
 		version := img.Version
@@ -140,8 +150,13 @@ func writeImageTable(sb *strings.Builder, images []domain.RecommendedImage) {
 			pinnedRef = "-"
 		}
 
-		fmt.Fprintf(sb, "| %d | `%s` | %s | %d | %d | %d | %s | %s | `%s` | `%s` |\n",
-			idx+1, img.Name, version,
+		alsoTagged := "-"
+		if len(img.AlternateTags) > 0 {
+			alsoTagged = strings.Join(img.AlternateTags, ", ")
+		}
+
+		fmt.Fprintf(sb, "| %d | `%s` | %s | %s | %d | %d | %d | %s | %s | `%s` | `%s` |\n",
+			idx+1, img.Name, version, alsoTagged,
 			img.CriticalVulnerabilities, img.HighVulnerabilities, img.TotalVulnerabilities,
 			HumanSize(img.SizeBytes), FormatCreatedDate(img.CreatedDate), FormatDigest(img.Digest), pinnedRef)
 	}
@@ -312,8 +327,8 @@ func FormatRecommendedImages(lang string, images []domain.RecommendedImage) stri
 	var sb strings.Builder
 
 	fmt.Fprintf(&sb, "## %s\n\n", DisplayLanguageName(lang))
-	sb.WriteString("| Rank | Image | Version | Crit | High | Total | Size | Created | Digest | Pinned Reference |\n")
-	sb.WriteString("|------|-------|---------|------|------|-------|------|---------|--------|------------------|\n")
+	sb.WriteString("| Rank | Image | Version | Also Tagged As | Crit | High | Total | Size | Created | Digest | Pinned Reference |\n")
+	sb.WriteString("|------|-------|---------|----------------|------|------|-------|------|---------|--------|------------------|\n")
 
 	for idx, img := range images {
 		version := img.Version
@@ -326,8 +341,13 @@ func FormatRecommendedImages(lang string, images []domain.RecommendedImage) stri
 			pinnedRef = "-"
 		}
 
-		fmt.Fprintf(&sb, "| %d | `%s` | %s | %d | %d | %d | %s | %s | `%s` | `%s` |\n",
-			idx+1, img.Name, version,
+		alsoTagged := "-"
+		if len(img.AlternateTags) > 0 {
+			alsoTagged = strings.Join(img.AlternateTags, ", ")
+		}
+
+		fmt.Fprintf(&sb, "| %d | `%s` | %s | %s | %d | %d | %d | %s | %s | `%s` | `%s` |\n",
+			idx+1, img.Name, version, alsoTagged,
 			img.CriticalVulnerabilities, img.HighVulnerabilities, img.TotalVulnerabilities,
 			HumanSize(img.SizeBytes), FormatCreatedDate(img.CreatedDate), FormatDigest(img.Digest), pinnedRef)
 	}

--- a/pkg/infrastructure/report/markdown_test.go
+++ b/pkg/infrastructure/report/markdown_test.go
@@ -219,7 +219,7 @@ func TestFormatRecommendedImagesIncludesCreatedDate(t *testing.T) {
 
 	content := FormatRecommendedImages("python", images)
 
-	assert.Contains(t, content, "| Rank | Image | Version | Crit | High | Total | Size | Created | Digest | Pinned Reference |")
-	assert.Contains(t, content, "| 1 | `mcr.microsoft.com/azurelinux/base/python:3.12` | 3.12.1 | 0 | 1 | 5 | 81.1 MB | 2025-04-15 | `sha256:abcdef123456` |")
-	assert.Contains(t, content, "| 2 | `empty-created:latest` | - | 0 | 0 | 0 | - | - | `` | `-` |")
+	assert.Contains(t, content, "| Rank | Image | Version | Also Tagged As | Crit | High | Total | Size | Created | Digest | Pinned Reference |")
+	assert.Contains(t, content, "| 1 | `mcr.microsoft.com/azurelinux/base/python:3.12` | 3.12.1 | - | 0 | 1 | 5 | 81.1 MB | 2025-04-15 | `sha256:abcdef123456` |")
+	assert.Contains(t, content, "| 2 | `empty-created:latest` | - | - | 0 | 0 | 0 | - | - | `` | `-` |")
 }


### PR DESCRIPTION
## Summary

Images with different tags but identical digests (e.g., nodejs:24 and nodejs:24.14) previously occupied multiple rows in the ranking tables. This PR deduplicates them at report generation time, showing the most specific tag as primary with alternates in an Also Tagged As column.

## Changes

- pkg/domain/models.go — Added AlternateTags to RecommendedImage
- pkg/infrastructure/report/dedup.go (new) — DeduplicateByDigest groups images by digest
- pkg/infrastructure/report/dedup_test.go (new) — 14 test cases
- pkg/infrastructure/report/markdown.go — Query all, dedup, topN; added Also Tagged As column
- pkg/infrastructure/report/json.go — Added alternateTags field; same dedup flow
- Updated test files for new column

## Design Decisions

- Report-level only — no database schema changes
- Tag specificity scoring — numeric tags beat latest, more segments beat fewer
- Empty digests never grouped
- TopN applied after dedup

Closes #35