### PR TITLE
feat(report): filter incidental runtimes from recommendations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,16 @@ Reports are grouped by **Language → Base OS → ranked table**:
 - Images with unknown/empty OS are grouped as "Other" (sorted last).
 - The **"Base / No Runtime"** section (language = `"base"`) always appears last, after all runtime language sections. It contains minimal images (e.g., `azurelinux/base/core`) suitable for deploying static binaries (Go, Rust).
 
+### Incidental Runtime Filtering
+
+At report generation time, images are filtered so that recommendation sections only include images whose **primary runtime** matches the section language. This prevents images with incidental secondary runtimes (e.g., Python installed as a system dependency in JDK images) from appearing in unrelated language sections.
+
+**How it works:** The primary language is inferred from the image's repository path segments. For example, `openjdk/jdk` → Java, `azurelinux/base/python` → Python, `dotnet/aspnet` → .NET. If no primary language can be inferred from the image name, the image is kept in all sections (safe fallback).
+
+**Mapped segments:** `python` → Python, `nodejs`/`node` → Node.js, `openjdk`/`jdk`/`jre` → Java, `golang`/`go` → Go, `dotnet`/`aspnet` → .NET, `ruby` → Ruby, `php` → PHP, `rust` → Rust.
+
+All detected languages are still stored in the database — the filtering is applied only when generating reports. The filter runs before deduplication and top-N limiting.
+
 **Language display names:** `"base"` → "Base / No Runtime", all others → title case (e.g., `"python"` → "Python").
 
 **OS display names:** `azurelinux` → "Azure Linux", `ubuntu` → "Ubuntu", `debian` → "Debian", `alpine` → "Alpine".

--- a/pkg/infrastructure/report/json.go
+++ b/pkg/infrastructure/report/json.go
@@ -110,6 +110,7 @@ func GenerateJSONReport(repo *database.Repository, outputPath string, topN int, 
 				continue
 			}
 
+			images = FilterIncidentalImages(images, lang)
 			images = DeduplicateByDigest(images)
 			if topN > 0 && len(images) > topN {
 				images = images[:topN]

--- a/pkg/infrastructure/report/json_test.go
+++ b/pkg/infrastructure/report/json_test.go
@@ -473,3 +473,108 @@ func TestGenerateMarkdownReport_DeduplicatesWithAlternateColumn(t *testing.T) {
 	// Only one ranked row should exist (rank 1, no rank 2)
 	assert.NotContains(t, content, "| 2 | `mcr", "should have only one image row after dedup")
 }
+
+func TestGenerateJSONReport_FiltersIncidentalRuntimes(t *testing.T) {
+	db, repo := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	// JDK image with both java and python (python is incidental)
+	jdkImage := domain.ImageRecord{
+		Name: "mcr.microsoft.com/openjdk/jdk:21-azurelinux", Registry: "mcr.microsoft.com",
+		Repository: "openjdk/jdk", Tag: "21-azurelinux",
+		BaseOSName: "azurelinux", TotalVulnerabilities: 3,
+		Languages: []domain.Language{
+			{Language: "java", Version: "21.0.6"},
+			{Language: "python", Version: "3.12.9"},
+		},
+	}
+	// Actual python image
+	pythonImage := domain.ImageRecord{
+		Name: "mcr.microsoft.com/azurelinux/base/python:3.12", Registry: "mcr.microsoft.com",
+		Repository: "azurelinux/base/python", Tag: "3.12",
+		BaseOSName: "azurelinux", TotalVulnerabilities: 2,
+		Languages: []domain.Language{
+			{Language: "python", Version: "3.12.9"},
+		},
+	}
+
+	require.NoError(t, repo.InsertImage(&jdkImage))
+	require.NoError(t, repo.InsertImage(&pythonImage))
+
+	outPath := filepath.Join(t.TempDir(), "report.json")
+	require.NoError(t, GenerateJSONReport(repo, outPath, 10, nil))
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	var report JSONReport
+	require.NoError(t, json.Unmarshal(data, &report))
+
+	// JDK image should appear in java section
+	var javaEntries, pythonEntries []JSONImageEntry
+	for _, img := range report.Images {
+		switch img.Language {
+		case "java":
+			javaEntries = append(javaEntries, img)
+		case "python":
+			pythonEntries = append(pythonEntries, img)
+		}
+	}
+
+	assert.Len(t, javaEntries, 1, "JDK image should appear in java")
+	assert.Equal(t, "mcr.microsoft.com/openjdk/jdk:21-azurelinux", javaEntries[0].Name)
+
+	// Python section should only have the actual python image, not the JDK
+	assert.Len(t, pythonEntries, 1, "only the actual python image should appear")
+	assert.Equal(t, "mcr.microsoft.com/azurelinux/base/python:3.12", pythonEntries[0].Name)
+}
+
+func TestGenerateMarkdownReport_FiltersIncidentalRuntimes(t *testing.T) {
+	db, repo := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	// JDK image with both java and python (python is incidental)
+	jdkImage := domain.ImageRecord{
+		Name: "mcr.microsoft.com/openjdk/jdk:21-azurelinux", Registry: "mcr.microsoft.com",
+		Repository: "openjdk/jdk", Tag: "21-azurelinux",
+		BaseOSName: "azurelinux", TotalVulnerabilities: 1,
+		Languages: []domain.Language{
+			{Language: "java", Version: "21.0.6"},
+			{Language: "python", Version: "3.12.9"},
+		},
+	}
+	pythonImage := domain.ImageRecord{
+		Name: "mcr.microsoft.com/azurelinux/base/python:3.12", Registry: "mcr.microsoft.com",
+		Repository: "azurelinux/base/python", Tag: "3.12",
+		BaseOSName: "azurelinux", TotalVulnerabilities: 2,
+		Languages: []domain.Language{
+			{Language: "python", Version: "3.12.9"},
+		},
+	}
+
+	require.NoError(t, repo.InsertImage(&jdkImage))
+	require.NoError(t, repo.InsertImage(&pythonImage))
+
+	outPath := filepath.Join(t.TempDir(), "report.md")
+	require.NoError(t, GenerateReport(repo, outPath, 10, nil))
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	content := string(data)
+
+	// Java section should contain the JDK image
+	assert.Contains(t, content, "## Java")
+	assert.Contains(t, content, "`mcr.microsoft.com/openjdk/jdk:21-azurelinux`")
+
+	// Python section should NOT contain the JDK image
+	assert.Contains(t, content, "## Python")
+	pythonIdx := strings.Index(content, "## Python")
+	javaIdx := strings.Index(content, "## Java")
+	// Find the Python section content (between Python heading and next heading or EOF)
+	pythonSection := content[pythonIdx:]
+	if javaIdx > pythonIdx {
+		pythonSection = content[pythonIdx:javaIdx]
+	}
+	assert.NotContains(t, pythonSection, "openjdk/jdk", "JDK image should not appear in Python section")
+	assert.Contains(t, pythonSection, "azurelinux/base/python", "actual python image should appear")
+}

--- a/pkg/infrastructure/report/json_test.go
+++ b/pkg/infrastructure/report/json_test.go
@@ -521,11 +521,11 @@ func TestGenerateJSONReport_FiltersIncidentalRuntimes(t *testing.T) {
 		}
 	}
 
-	assert.Len(t, javaEntries, 1, "JDK image should appear in java")
+	require.Len(t, javaEntries, 1, "JDK image should appear in java")
 	assert.Equal(t, "mcr.microsoft.com/openjdk/jdk:21-azurelinux", javaEntries[0].Name)
 
 	// Python section should only have the actual python image, not the JDK
-	assert.Len(t, pythonEntries, 1, "only the actual python image should appear")
+	require.Len(t, pythonEntries, 1, "only the actual python image should appear")
 	assert.Equal(t, "mcr.microsoft.com/azurelinux/base/python:3.12", pythonEntries[0].Name)
 }
 
@@ -563,13 +563,14 @@ func TestGenerateMarkdownReport_FiltersIncidentalRuntimes(t *testing.T) {
 	content := string(data)
 
 	// Java section should contain the JDK image
-	assert.Contains(t, content, "## Java")
-	assert.Contains(t, content, "`mcr.microsoft.com/openjdk/jdk:21-azurelinux`")
+	require.Contains(t, content, "## Java")
+	require.Contains(t, content, "`mcr.microsoft.com/openjdk/jdk:21-azurelinux`")
 
 	// Python section should NOT contain the JDK image
-	assert.Contains(t, content, "## Python")
+	require.Contains(t, content, "## Python")
 	pythonIdx := strings.Index(content, "## Python")
 	javaIdx := strings.Index(content, "## Java")
+	require.NotEqual(t, -1, pythonIdx, "Python section must exist")
 	// Find the Python section content (between Python heading and next heading or EOF)
 	pythonSection := content[pythonIdx:]
 	if javaIdx > pythonIdx {

--- a/pkg/infrastructure/report/markdown.go
+++ b/pkg/infrastructure/report/markdown.go
@@ -83,6 +83,7 @@ func GenerateReport(repo *database.Repository, outputPath string, topN int, repo
 				continue
 			}
 
+			images = FilterIncidentalImages(images, lang)
 			images = DeduplicateByDigest(images)
 			if topN > 0 && len(images) > topN {
 				images = images[:topN]
@@ -99,6 +100,7 @@ func GenerateReport(repo *database.Repository, outputPath string, topN int, repo
 					continue
 				}
 
+				osImages = FilterIncidentalImages(osImages, lang)
 				osImages = DeduplicateByDigest(osImages)
 				if topN > 0 && len(osImages) > topN {
 					osImages = osImages[:topN]

--- a/pkg/infrastructure/report/primary.go
+++ b/pkg/infrastructure/report/primary.go
@@ -1,0 +1,80 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package report
+
+import (
+	"strings"
+
+	"github.com/microsoft/sbi/pkg/domain"
+)
+
+// primaryLanguageSegments maps repository path segments to their primary language.
+// Only exact segment matches are used to avoid false positives.
+var primaryLanguageSegments = map[string]string{
+	"python":  "python",
+	"nodejs":  "node",
+	"node":    "node",
+	"openjdk": "java",
+	"jdk":     "java",
+	"jre":     "java",
+	"golang":  "go",
+	"go":      "go",
+	"dotnet":  "dotnet",
+	"aspnet":  "dotnet",
+	"ruby":    "ruby",
+	"php":     "php",
+	"rust":    "rust",
+}
+
+// InferPrimaryLanguage infers the primary language of an image from its
+// repository path. Returns the language name (matching the DB convention)
+// or "" if no primary language can be determined.
+func InferPrimaryLanguage(imageName string) string {
+	repo := imageRepo(imageName)
+	segments := strings.Split(strings.ToLower(repo), "/")
+
+	for _, seg := range segments {
+		if lang, ok := primaryLanguageSegments[seg]; ok {
+			return lang
+		}
+	}
+
+	return ""
+}
+
+// FilterIncidentalImages removes images whose inferred primary language
+// differs from the queried language. Images with no inferred primary
+// language are kept (safe fallback).
+func FilterIncidentalImages(images []domain.RecommendedImage, queriedLang string) []domain.RecommendedImage {
+	queriedLang = strings.ToLower(queriedLang)
+	result := make([]domain.RecommendedImage, 0, len(images))
+
+	for _, img := range images {
+		primary := InferPrimaryLanguage(img.Name)
+		if primary == "" || primary == queriedLang {
+			result = append(result, img)
+		}
+	}
+
+	return result
+}

--- a/pkg/infrastructure/report/primary_test.go
+++ b/pkg/infrastructure/report/primary_test.go
@@ -1,0 +1,130 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package report
+
+import (
+	"testing"
+
+	"github.com/microsoft/sbi/pkg/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInferPrimaryLanguage(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected string
+	}{
+		// Python images
+		{"azure linux base python", "mcr.microsoft.com/azurelinux/base/python:3.12", "python"},
+		{"azure linux distroless python", "mcr.microsoft.com/azurelinux/distroless/python:3.12-nonroot", "python"},
+
+		// Node.js images
+		{"azure linux base nodejs", "mcr.microsoft.com/azurelinux/base/nodejs:24", "node"},
+		{"azure linux distroless nodejs", "mcr.microsoft.com/azurelinux/distroless/nodejs:24.14", "node"},
+
+		// Java images
+		{"openjdk jdk azurelinux", "mcr.microsoft.com/openjdk/jdk:21-azurelinux", "java"},
+		{"openjdk jdk distroless", "mcr.microsoft.com/openjdk/jdk:25-distroless", "java"},
+		{"openjdk jdk ubuntu", "mcr.microsoft.com/openjdk/jdk:21-ubuntu", "java"},
+
+		// .NET images
+		{"dotnet aspnet azurelinux", "mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless", "dotnet"},
+		{"dotnet runtime noble", "mcr.microsoft.com/dotnet/runtime:10.0-noble", "dotnet"},
+		{"dotnet sdk", "mcr.microsoft.com/dotnet/sdk:9.0-azurelinux3.0", "dotnet"},
+		{"dotnet aspnet debian", "mcr.microsoft.com/dotnet/aspnet:8.0", "dotnet"},
+
+		// Go images
+		{"golang azurelinux", "mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0", "go"},
+
+		// No match — safe fallback
+		{"base core image", "mcr.microsoft.com/azurelinux/base/core:3.0", ""},
+		{"distroless base", "mcr.microsoft.com/azurelinux/distroless/base:3.0", ""},
+		{"distroless minimal", "mcr.microsoft.com/azurelinux/distroless/minimal:3.0", ""},
+		{"custom image", "my-custom-image:latest", ""},
+		{"docker hub short name", "ubuntu:22.04", ""},
+		{"empty string", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, InferPrimaryLanguage(tt.image))
+		})
+	}
+}
+
+func TestFilterIncidentalImages(t *testing.T) {
+	jdkImage := domain.RecommendedImage{
+		Name:    "mcr.microsoft.com/openjdk/jdk:21-azurelinux",
+		Version: "3.12.9",
+	}
+	pythonImage := domain.RecommendedImage{
+		Name:    "mcr.microsoft.com/azurelinux/base/python:3.12",
+		Version: "3.12.9",
+	}
+	customImage := domain.RecommendedImage{
+		Name:    "my-custom-image:latest",
+		Version: "3.12.0",
+	}
+
+	t.Run("filters JDK from python results", func(t *testing.T) {
+		images := []domain.RecommendedImage{jdkImage, pythonImage}
+		result := FilterIncidentalImages(images, "python")
+		assert.Len(t, result, 1)
+		assert.Equal(t, pythonImage.Name, result[0].Name)
+	})
+
+	t.Run("keeps JDK in java results", func(t *testing.T) {
+		images := []domain.RecommendedImage{jdkImage}
+		result := FilterIncidentalImages(images, "java")
+		assert.Len(t, result, 1)
+		assert.Equal(t, jdkImage.Name, result[0].Name)
+	})
+
+	t.Run("keeps images with no inferred primary", func(t *testing.T) {
+		images := []domain.RecommendedImage{customImage, pythonImage}
+		result := FilterIncidentalImages(images, "python")
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		result := FilterIncidentalImages(nil, "python")
+		assert.Empty(t, result)
+	})
+
+	t.Run("all filtered returns empty", func(t *testing.T) {
+		images := []domain.RecommendedImage{jdkImage}
+		result := FilterIncidentalImages(images, "python")
+		assert.Empty(t, result)
+	})
+
+	t.Run("dotnet image filtered from python", func(t *testing.T) {
+		dotnetImage := domain.RecommendedImage{
+			Name: "mcr.microsoft.com/dotnet/sdk:9.0-azurelinux3.0",
+		}
+		images := []domain.RecommendedImage{dotnetImage, pythonImage}
+		result := FilterIncidentalImages(images, "python")
+		assert.Len(t, result, 1)
+		assert.Equal(t, pythonImage.Name, result[0].Name)
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #37 — Images with incidental secondary runtimes (e.g., Python in JDK images) are now filtered from recommendation sections where they don't belong.

## Approach

**Report-time filtering** — no schema, model, or config changes.

Two new functions in `pkg/infrastructure/report/primary.go`:
- `InferPrimaryLanguage(imageName)` — infers the primary language from repository path segments (e.g., `openjdk/jdk` → `java`, `azurelinux/base/python` → `python`)
- `FilterIncidentalImages(images, queriedLang)` — removes images whose inferred primary language doesn't match the queried section

### How it works

| Image | Inferred Primary | Appears in Java? | Appears in Python? |
|-------|-----------------|-------------------|---------------------|
| `openjdk/jdk:21-azurelinux` | `java` | ✅ Yes | ❌ Filtered out |
| `azurelinux/base/python:3.12` | `python` | ❌ Filtered out | ✅ Yes |
| `my-custom-image:latest` | (none) | ✅ Kept (safe fallback) | ✅ Kept (safe fallback) |

### Design decisions

- **Filter order:** Query → Filter → Dedup → TopN (prevents incidental images from merging during dedup)
- **Safe fallback:** Images with unrecognized names are kept in all sections
- **Data preservation:** All languages remain in the DB — filtering is report-time only
- **Base / No Runtime:** Unaffected (no language segment match → safe fallback; these images only have the synthetic `base` language)

## Files changed

| File | Change |
|------|--------|
| `pkg/infrastructure/report/primary.go` | New: inference + filter functions |
| `pkg/infrastructure/report/primary_test.go` | New: 24 unit tests |
| `pkg/infrastructure/report/markdown.go` | Filter call in single-OS and multi-OS paths |
| `pkg/infrastructure/report/json.go` | Filter call before dedup |
| `pkg/infrastructure/report/json_test.go` | 2 integration tests (JSON + Markdown) |
| `AGENTS.md` | Documented filtering behavior |

## Testing

- All existing tests pass unchanged
- New unit tests cover all image families in `config/repositories.json`
- Integration tests verify JDK images are filtered from Python section in both report formats