### PR TITLE
feat(report): add detailed per-image JSON report with --detailed flag

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 # Storing the DB with LFS prevents repo bloat from daily binary diffs.
 # You must run `git lfs install` locally (once per machine) after pulling this change.
 azure_linux_images.db filter=lfs diff=lfs merge=lfs -text
+docs/*_detail.json filter=lfs diff=lfs merge=lfs -text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ pkg/
   infrastructure/
     database/                 # SQLite schema, persistence, ranked queries
       schema.go               # Table definitions (images, languages, vulnerabilities, etc.)
-      repository.go           # InsertImage (upsert), QueryTopImages, QueryLanguages
+      repository.go           # InsertImage (upsert), QueryTopImages, QueryLanguages, QueryAllImageDetails
     scanner/
       analyzer.go             # Orchestrates: pull -> inspect -> syft -> trivy -> verify
       syft.go                 # SBOM parsing, language detection from packages
@@ -28,7 +28,8 @@ pkg/
       docker.go               # Docker pull, inspect, run commands in containers
     report/
       markdown.go             # Markdown report generation
-      json.go                 # JSON report generation
+      json.go                 # JSON summary report generation
+      json_detail.go          # Detailed per-image JSON report (packages, CVEs, languages)
   usecase/
     pipeline.go               # Top-level orchestration: config -> discover -> scan -> report
 config/
@@ -87,6 +88,7 @@ sbi reset-db --database azure_linux_images.db
 - `--json-top-n N` — number of top images per language per base OS in JSON report (default 20, 0 = all)
 - `--max-tags N` — limit tags per repository (0 = all)
 - `--comprehensive` — enable secrets + misconfiguration scanning
+- `--detailed` — generate a detailed per-image JSON report with full package/vulnerability/language data
 - `--update-existing` — rescan images already in the database
 - `--no-cleanup` — keep Docker images after scanning
 
@@ -273,6 +275,10 @@ The JSON report uses a flat `images` array — each entry has `language` and `ba
 JSON top-N defaults to 20 (configurable via `--json-top-n`, 0 = all). Rank resets per language+OS group. Each entry includes `createdDate`, `pinnedReference`, `stableTag`, and `dockerfileFrom`.
 
 `RecommendedImage` includes image name, language version, vulnerability counts, size, created date, digest, and base OS for report generation.
+
+### Detailed JSON Report
+
+When `--detailed` is passed, a separate `*_detail.json` file is generated with per-image package inventories, vulnerability breakdowns (CVE ID, severity, CVSS, fix availability), system packages, package managers, and detected languages. This report covers all scanned images (not top-N filtered), uses a flat `images` array with one entry per DB image, and includes a `schemaVersion` field for forward compatibility. See [docs/detailed-report.md](docs/detailed-report.md) for schema and jq query examples.
 
 ## Database Schema
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Every night, this project scans configured MCR (Microsoft Container Registry) co
 |----------|--------------------------------------------------------------------|
 | Markdown | [docs/daily_recommendations.md](docs/daily_recommendations.md)     |
 | JSON     | [docs/daily_recommendations.json](docs/daily_recommendations.json) |
+| Detailed JSON | [On-demand with `--detailed`](docs/detailed-report.md) (per-image packages, CVEs, languages) |
 
 Reports are regenerated nightly at 02:00 UTC via [GitHub Actions](.github/workflows/nightly-scan.yml) and committed automatically. Images are ranked per language by: fewest critical → fewest high → fewest total vulnerabilities → smallest size.
 
@@ -48,6 +49,9 @@ sbi scan --verbose
 # Regenerate reports from existing database
 sbi report
 
+# Generate reports with detailed per-image breakdown
+sbi report --detailed
+
 # Clear the database
 sbi reset-db
 ```
@@ -70,6 +74,7 @@ task build
 | `--output` | `docs/daily_recommendations.md` | Path to output report file |
 | `--top-n` | 10 | Number of top images per language per base OS (0 = all) |
 | `--json-top-n` | 20 | Number of top images per language per base OS in JSON report (0 = all) |
+| `--detailed` | false | Generate detailed per-image JSON report with packages and vulnerabilities |
 | `--verbose, -v` | false | Enable verbose output |
 | `--debug, -d` | false | Enable debug output |
 
@@ -81,6 +86,8 @@ task build
 | `--comprehensive` | false | Enable comprehensive scanning (secrets + misconfigs) |
 | `--update-existing` | false | Rescan existing images |
 | `--no-cleanup` | false | Keep Docker images after scanning |
+
+> **Tip:** The `--detailed` flag generates a rich per-image JSON report with packages, CVEs, and languages. See [docs/detailed-report.md](docs/detailed-report.md) for the report schema and jq query examples.
 
 ## Configuration
 

--- a/docs/detailed-report.md
+++ b/docs/detailed-report.md
@@ -1,0 +1,127 @@
+# Detailed JSON Report
+
+The `--detailed` flag generates a separate `*_detail.json` report with per-image package inventories, vulnerability breakdowns, and detected languages. This report covers **all** scanned images (not top-N filtered) and is designed for downstream tooling and drill-down analysis.
+
+## Generating the Report
+
+```bash
+# Generate all reports including the detailed JSON
+sbi scan --detailed --verbose
+
+# Or regenerate from an existing database
+sbi report --detailed
+```
+
+The detailed report is written alongside the other reports as `docs/daily_recommendations_detail.json` (derived from the `--output` path).
+
+## Report Structure
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-27T11:27:25Z",
+  "imageCount": 122,
+  "images": [
+    {
+      "name": "mcr.microsoft.com/azurelinux/base/python:3.12",
+      "registry": "mcr.microsoft.com",
+      "repository": "azurelinux/base/python",
+      "tag": "3.12",
+      "digest": "sha256:...",
+      "sizeBytes": 145752064,
+      "sizeHuman": "139.0 MB",
+      "layers": 3,
+      "createdDate": "2026-05-17T10:17:59Z",
+      "scanTimestamp": "2026-05-27T05:43:37Z",
+      "baseOS": { "name": "Azure Linux", "version": "3.0" },
+      "vulnerabilitySummary": {
+        "total": 1, "critical": 0, "high": 1,
+        "medium": 0, "low": 0, "negligible": 0, "unknown": 0
+      },
+      "languages": [
+        { "language": "python", "version": "3.12.9", "majorMinor": "3.12",
+          "packageName": "python3", "packageType": "rpm", "verified": true }
+      ],
+      "vulnerabilities": [
+        { "id": "CVE-2026-4046", "severity": "HIGH", "cvssScore": 5.3,
+          "packageName": "glibc", "packageVersion": "2.38-19.azl3",
+          "fixedVersion": "2.38-20.azl3", "description": "..." }
+      ],
+      "systemPackages": [
+        { "name": "openssl", "version": "3.0.1", "packageType": "rpm" }
+      ],
+      "packageManagers": [
+        { "name": "pip", "version": "24.0", "language": "python" }
+      ]
+    }
+  ]
+}
+```
+
+> **Optional fields:** Some fields are omitted when empty or unknown, including `registry`, `repository`, `tag`, `digest`, `scanTimestamp`, `baseOS.version`, `languages[].majorMinor`, `languages[].packageName`, `languages[].packageType`, `vulnerabilities[].fixedVersion`, and `vulnerabilities[].description`. Array fields (`languages`, `vulnerabilities`, `systemPackages`, `packageManagers`) are always present as empty arrays `[]`, never null.
+>
+> **Scope:** The current detailed report includes system packages, package managers, detected languages, and CVE vulnerabilities. Comprehensive scan findings (secrets, misconfigurations) and capabilities are not included.
+
+## Querying with jq
+
+### Get full details for a specific image
+
+```bash
+jq '.images[] | select(.name | contains("python:3.12"))' docs/daily_recommendations_detail.json
+```
+
+### Summary view with package counts
+
+```bash
+jq '.images[] | select(.name | contains("python:3.12")) | {
+  name, baseOS, vulnerabilitySummary, languages,
+  systemPackageCount: (.systemPackages | length),
+  packageManagerCount: (.packageManagers | length)
+}' docs/daily_recommendations_detail.json
+```
+
+### List all images with critical vulnerabilities
+
+```bash
+jq '.images[] | select(.vulnerabilitySummary.critical > 0) |
+  {name, critical: .vulnerabilitySummary.critical}' docs/daily_recommendations_detail.json
+```
+
+### Show CVEs with available fixes
+
+```bash
+jq '.images[] | select(.name | contains("python:3.12")) |
+  .vulnerabilities[] | select((.fixedVersion // "") != "") |
+  {id, severity, packageName, fixedVersion}' docs/daily_recommendations_detail.json
+```
+
+### Count system packages per image
+
+```bash
+jq '.images[] | {name, packages: (.systemPackages | length)} |
+  select(.packages > 0)' docs/daily_recommendations_detail.json
+```
+
+### Find images with the most vulnerabilities
+
+```bash
+jq '[.images[] | {name, total: .vulnerabilitySummary.total}] |
+  sort_by(-.total) | .[0:10]' docs/daily_recommendations_detail.json
+```
+
+### List all HIGH/CRITICAL CVEs across all images
+
+```bash
+jq '[.images[] as $img | $img.vulnerabilities[] |
+  select(.severity == "CRITICAL" or .severity == "HIGH") |
+  {image: $img.name, id, severity, cvssScore, packageName, fixedVersion}] |
+  sort_by(-.cvssScore)' docs/daily_recommendations_detail.json
+```
+
+## Git LFS
+
+The detailed report can be large (several MB for hundreds of images). The `docs/*_detail.json` pattern is tracked via Git LFS in `.gitattributes` to avoid repository bloat.
+
+## Schema Versioning
+
+The report includes a `schemaVersion` field (currently `1`) to support forward-compatible changes. Downstream consumers should check this field to detect breaking schema changes.

--- a/pkg/domain/models.go
+++ b/pkg/domain/models.go
@@ -138,6 +138,7 @@ type ScanConfig struct {
 	CleanupImages     bool
 	UpdateExisting    bool
 	Verbose           bool
+	Detailed          bool
 }
 
 // RepositoryConfig represents the JSON configuration for image sources and tag filtering.

--- a/pkg/infrastructure/database/repository.go
+++ b/pkg/infrastructure/database/repository.go
@@ -357,6 +357,205 @@ func (r *Repository) ClearDatabase() error {
 	return nil
 }
 
+// QueryAllImageDetails returns every image with its child data populated
+// (languages, vulnerabilities, system packages, package managers).
+// Uses batched eager loading within a read transaction for snapshot consistency.
+func (r *Repository) QueryAllImageDetails() ([]domain.ImageRecord, error) {
+	tx, err := r.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("beginning read transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Step 1: Load all images
+	imgRows, err := tx.Query(`
+		SELECT id, name, registry, repository, tag, digest,
+		       COALESCE(size_bytes, 0), layers, COALESCE(created_date, ''),
+		       COALESCE(scan_timestamp, ''), COALESCE(base_os_name, ''),
+		       COALESCE(base_os_version, ''),
+		       total_vulnerabilities, critical_vulnerabilities, high_vulnerabilities,
+		       medium_vulnerabilities, low_vulnerabilities, negligible_vulnerabilities,
+		       unknown_vulnerabilities
+		FROM images
+		ORDER BY name ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("querying images: %w", err)
+	}
+
+	imageMap := make(map[int64]*domain.ImageRecord)
+	var imageOrder []int64
+
+	for imgRows.Next() {
+		var img domain.ImageRecord
+		if err := imgRows.Scan(
+			&img.ID, &img.Name, &img.Registry, &img.Repository, &img.Tag, &img.Digest,
+			&img.SizeBytes, &img.Layers, &img.CreatedDate,
+			&img.ScanTimestamp, &img.BaseOSName, &img.BaseOSVersion,
+			&img.TotalVulnerabilities, &img.CriticalVulnerabilities, &img.HighVulnerabilities,
+			&img.MediumVulnerabilities, &img.LowVulnerabilities, &img.NegligibleVulnerabilities,
+			&img.UnknownVulnerabilities,
+		); err != nil {
+			_ = imgRows.Close()
+			return nil, fmt.Errorf("scanning image: %w", err)
+		}
+
+		imageMap[img.ID] = &img
+		imageOrder = append(imageOrder, img.ID)
+	}
+
+	if err := imgRows.Close(); err != nil {
+		return nil, fmt.Errorf("closing image rows: %w", err)
+	}
+
+	if err := imgRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating images: %w", err)
+	}
+
+	if len(imageMap) == 0 {
+		return nil, nil
+	}
+
+	// Step 2: Load languages
+	langRows, err := tx.Query(`
+		SELECT image_id, language, COALESCE(version, ''), COALESCE(major_minor, ''),
+		       COALESCE(package_name, ''), COALESCE(package_type, ''), verified
+		FROM languages ORDER BY image_id, id`)
+	if err != nil {
+		return nil, fmt.Errorf("querying languages: %w", err)
+	}
+
+	for langRows.Next() {
+		var imageID int64
+		var l domain.Language
+		var verified int
+
+		if err := langRows.Scan(&imageID, &l.Language, &l.Version, &l.MajorMinor,
+			&l.PackageName, &l.PackageType, &verified); err != nil {
+			_ = langRows.Close()
+			return nil, fmt.Errorf("scanning language: %w", err)
+		}
+
+		l.Verified = verified != 0
+
+		if img, ok := imageMap[imageID]; ok {
+			img.Languages = append(img.Languages, l)
+		}
+	}
+
+	if err := langRows.Close(); err != nil {
+		return nil, fmt.Errorf("closing language rows: %w", err)
+	}
+
+	if err := langRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating languages: %w", err)
+	}
+
+	// Step 3: Load vulnerabilities
+	vulnRows, err := tx.Query(`
+		SELECT image_id, COALESCE(vulnerability_id, ''), COALESCE(severity, ''),
+		       COALESCE(package_name, ''), COALESCE(package_version, ''),
+		       COALESCE(fixed_version, ''), COALESCE(description, ''),
+		       COALESCE(cvss_score, 0)
+		FROM vulnerabilities ORDER BY image_id, id`)
+	if err != nil {
+		return nil, fmt.Errorf("querying vulnerabilities: %w", err)
+	}
+
+	for vulnRows.Next() {
+		var imageID int64
+		var v domain.Vulnerability
+
+		if err := vulnRows.Scan(&imageID, &v.VulnerabilityID, &v.Severity,
+			&v.PackageName, &v.PackageVersion, &v.FixedVersion,
+			&v.Description, &v.CVSSScore); err != nil {
+			_ = vulnRows.Close()
+			return nil, fmt.Errorf("scanning vulnerability: %w", err)
+		}
+
+		if img, ok := imageMap[imageID]; ok {
+			img.Vulnerabilities = append(img.Vulnerabilities, v)
+		}
+	}
+
+	if err := vulnRows.Close(); err != nil {
+		return nil, fmt.Errorf("closing vulnerability rows: %w", err)
+	}
+
+	if err := vulnRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating vulnerabilities: %w", err)
+	}
+
+	// Step 4: Load system packages
+	spRows, err := tx.Query(`
+		SELECT image_id, COALESCE(name, ''), COALESCE(version, ''),
+		       COALESCE(package_type, '')
+		FROM system_packages ORDER BY image_id, id`)
+	if err != nil {
+		return nil, fmt.Errorf("querying system packages: %w", err)
+	}
+
+	for spRows.Next() {
+		var imageID int64
+		var sp domain.SystemPackage
+
+		if err := spRows.Scan(&imageID, &sp.Name, &sp.Version, &sp.PackageType); err != nil {
+			_ = spRows.Close()
+			return nil, fmt.Errorf("scanning system package: %w", err)
+		}
+
+		if img, ok := imageMap[imageID]; ok {
+			img.SystemPackages = append(img.SystemPackages, sp)
+		}
+	}
+
+	if err := spRows.Close(); err != nil {
+		return nil, fmt.Errorf("closing system package rows: %w", err)
+	}
+
+	if err := spRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating system packages: %w", err)
+	}
+
+	// Step 5: Load package managers
+	pmRows, err := tx.Query(`
+		SELECT image_id, COALESCE(name, ''), COALESCE(version, ''),
+		       COALESCE(language, '')
+		FROM package_managers ORDER BY image_id, id`)
+	if err != nil {
+		return nil, fmt.Errorf("querying package managers: %w", err)
+	}
+
+	for pmRows.Next() {
+		var imageID int64
+		var pm domain.PackageManager
+
+		if err := pmRows.Scan(&imageID, &pm.Name, &pm.Version, &pm.Language); err != nil {
+			_ = pmRows.Close()
+			return nil, fmt.Errorf("scanning package manager: %w", err)
+		}
+
+		if img, ok := imageMap[imageID]; ok {
+			img.PackageManagers = append(img.PackageManagers, pm)
+		}
+	}
+
+	if err := pmRows.Close(); err != nil {
+		return nil, fmt.Errorf("closing package manager rows: %w", err)
+	}
+
+	if err := pmRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating package managers: %w", err)
+	}
+
+	// Assemble in original order
+	results := make([]domain.ImageRecord, 0, len(imageOrder))
+	for _, id := range imageOrder {
+		results = append(results, *imageMap[id])
+	}
+
+	return results, nil
+}
+
 // GetDatabaseStats returns basic statistics about the database.
 func (r *Repository) GetDatabaseStats() (map[string]int, error) {
 	stats := make(map[string]int)

--- a/pkg/infrastructure/report/json_detail.go
+++ b/pkg/infrastructure/report/json_detail.go
@@ -1,0 +1,228 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/microsoft/sbi/pkg/infrastructure/database"
+	log "github.com/sirupsen/logrus"
+)
+
+// DetailJSONReport is the top-level structure for the detailed JSON report.
+type DetailJSONReport struct {
+	SchemaVersion int                `json:"schemaVersion"`
+	GeneratedAt   string             `json:"generatedAt"`
+	ImageCount    int                `json:"imageCount"`
+	Images        []DetailImageEntry `json:"images"`
+}
+
+// DetailImageEntry represents a single image with full detail data.
+type DetailImageEntry struct {
+	Name                 string                  `json:"name"`
+	Registry             string                  `json:"registry,omitempty"`
+	Repository           string                  `json:"repository,omitempty"`
+	Tag                  string                  `json:"tag,omitempty"`
+	Digest               string                  `json:"digest,omitempty"`
+	SizeBytes            int64                   `json:"sizeBytes"`
+	SizeHuman            string                  `json:"sizeHuman"`
+	Layers               int                     `json:"layers"`
+	CreatedDate          string                  `json:"createdDate"`
+	ScanTimestamp        string                  `json:"scanTimestamp,omitempty"`
+	BaseOS               DetailBaseOS            `json:"baseOS"`
+	VulnerabilitySummary DetailVulnSummary       `json:"vulnerabilitySummary"`
+	Languages            []DetailLanguageEntry   `json:"languages"`
+	Vulnerabilities      []DetailVulnEntry       `json:"vulnerabilities"`
+	SystemPackages       []DetailSystemPkgEntry  `json:"systemPackages"`
+	PackageManagers      []DetailPkgManagerEntry `json:"packageManagers"`
+}
+
+// DetailBaseOS holds the OS information for an image.
+type DetailBaseOS struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+// DetailVulnSummary holds vulnerability counts by severity.
+type DetailVulnSummary struct {
+	Total      int `json:"total"`
+	Critical   int `json:"critical"`
+	High       int `json:"high"`
+	Medium     int `json:"medium"`
+	Low        int `json:"low"`
+	Negligible int `json:"negligible"`
+	Unknown    int `json:"unknown"`
+}
+
+// DetailLanguageEntry represents a detected language/runtime.
+type DetailLanguageEntry struct {
+	Language    string `json:"language"`
+	Version     string `json:"version"`
+	MajorMinor  string `json:"majorMinor,omitempty"`
+	PackageName string `json:"packageName,omitempty"`
+	PackageType string `json:"packageType,omitempty"`
+	Verified    bool   `json:"verified"`
+}
+
+// DetailVulnEntry represents a single vulnerability.
+type DetailVulnEntry struct {
+	ID             string  `json:"id"`
+	Severity       string  `json:"severity"`
+	CVSSScore      float64 `json:"cvssScore"`
+	PackageName    string  `json:"packageName"`
+	PackageVersion string  `json:"packageVersion"`
+	FixedVersion   string  `json:"fixedVersion,omitempty"`
+	Description    string  `json:"description,omitempty"`
+}
+
+// DetailSystemPkgEntry represents an OS-level package.
+type DetailSystemPkgEntry struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	PackageType string `json:"packageType,omitempty"`
+}
+
+// DetailPkgManagerEntry represents a detected package manager.
+type DetailPkgManagerEntry struct {
+	Name     string `json:"name"`
+	Version  string `json:"version,omitempty"`
+	Language string `json:"language,omitempty"`
+}
+
+// GenerateDetailJSONReport produces a detailed JSON report with per-image
+// package inventories, vulnerability breakdowns, and detected languages.
+func GenerateDetailJSONReport(repo *database.Repository, outputPath string) error {
+	images, err := repo.QueryAllImageDetails()
+	if err != nil {
+		return fmt.Errorf("querying image details: %w", err)
+	}
+
+	if len(images) == 0 {
+		log.Warn("No images found in database; detailed JSON report not generated.")
+		// Remove any stale detail report from a previous run
+		_ = os.Remove(outputPath)
+		return nil
+	}
+
+	report := DetailJSONReport{
+		SchemaVersion: 1,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		ImageCount:  len(images),
+		Images:      make([]DetailImageEntry, 0, len(images)),
+	}
+
+	for _, img := range images {
+		entry := DetailImageEntry{
+			Name:          img.Name,
+			Registry:      img.Registry,
+			Repository:    img.Repository,
+			Tag:           img.Tag,
+			Digest:        img.Digest,
+			SizeBytes:     img.SizeBytes,
+			SizeHuman:     HumanSize(img.SizeBytes),
+			Layers:        img.Layers,
+			CreatedDate:   img.CreatedDate,
+			ScanTimestamp: img.ScanTimestamp,
+			BaseOS: DetailBaseOS{
+				Name:    DisplayOSName(img.BaseOSName),
+				Version: img.BaseOSVersion,
+			},
+			VulnerabilitySummary: DetailVulnSummary{
+				Total:      img.TotalVulnerabilities,
+				Critical:   img.CriticalVulnerabilities,
+				High:       img.HighVulnerabilities,
+				Medium:     img.MediumVulnerabilities,
+				Low:        img.LowVulnerabilities,
+				Negligible: img.NegligibleVulnerabilities,
+				Unknown:    img.UnknownVulnerabilities,
+			},
+			Languages:       make([]DetailLanguageEntry, 0, len(img.Languages)),
+			Vulnerabilities: make([]DetailVulnEntry, 0, len(img.Vulnerabilities)),
+			SystemPackages:  make([]DetailSystemPkgEntry, 0, len(img.SystemPackages)),
+			PackageManagers: make([]DetailPkgManagerEntry, 0, len(img.PackageManagers)),
+		}
+
+		for _, l := range img.Languages {
+			entry.Languages = append(entry.Languages, DetailLanguageEntry{
+				Language:    l.Language,
+				Version:     l.Version,
+				MajorMinor:  l.MajorMinor,
+				PackageName: l.PackageName,
+				PackageType: l.PackageType,
+				Verified:    l.Verified,
+			})
+		}
+
+		for _, v := range img.Vulnerabilities {
+			entry.Vulnerabilities = append(entry.Vulnerabilities, DetailVulnEntry{
+				ID:             v.VulnerabilityID,
+				Severity:       v.Severity,
+				CVSSScore:      v.CVSSScore,
+				PackageName:    v.PackageName,
+				PackageVersion: v.PackageVersion,
+				FixedVersion:   v.FixedVersion,
+				Description:    v.Description,
+			})
+		}
+
+		for _, sp := range img.SystemPackages {
+			entry.SystemPackages = append(entry.SystemPackages, DetailSystemPkgEntry{
+				Name:        sp.Name,
+				Version:     sp.Version,
+				PackageType: sp.PackageType,
+			})
+		}
+
+		for _, pm := range img.PackageManagers {
+			entry.PackageManagers = append(entry.PackageManagers, DetailPkgManagerEntry{
+				Name:     pm.Name,
+				Version:  pm.Version,
+				Language: pm.Language,
+			})
+		}
+
+		report.Images = append(report.Images, entry)
+	}
+
+	dir := filepath.Dir(outputPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling detailed JSON report: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, data, 0o644); err != nil {
+		return fmt.Errorf("writing detailed JSON report: %w", err)
+	}
+
+	log.Infof("Wrote detailed JSON report to %s (%d images)", outputPath, len(images))
+
+	return nil
+}

--- a/pkg/infrastructure/report/json_detail_test.go
+++ b/pkg/infrastructure/report/json_detail_test.go
@@ -1,0 +1,262 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package report
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/sbi/pkg/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateDetailJSONReport_FullImage(t *testing.T) {
+	db, repo := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	img := &domain.ImageRecord{
+		Name: "mcr.microsoft.com/azurelinux/base/python:3.12", Registry: "mcr.microsoft.com",
+		Repository: "azurelinux/base/python", Tag: "3.12",
+		BaseOSName: "azurelinux", BaseOSVersion: "3.0",
+		Digest: "sha256:abc123", SizeBytes: 85000000, Layers: 5,
+		CreatedDate: "2025-04-15T08:30:00Z",
+		TotalVulnerabilities: 3, CriticalVulnerabilities: 1, HighVulnerabilities: 1,
+		MediumVulnerabilities: 1,
+		Languages: []domain.Language{
+			{Language: "python", Version: "3.12.9", MajorMinor: "3.12", PackageName: "python3", PackageType: "rpm", Verified: true},
+		},
+		Vulnerabilities: []domain.Vulnerability{
+			{VulnerabilityID: "CVE-2025-0001", Severity: "CRITICAL", PackageName: "openssl", PackageVersion: "3.0.1", FixedVersion: "3.0.2", CVSSScore: 9.8, Description: "Buffer overflow"},
+			{VulnerabilityID: "CVE-2025-0002", Severity: "HIGH", PackageName: "curl", PackageVersion: "7.88.0", FixedVersion: "7.88.1", CVSSScore: 7.5},
+			{VulnerabilityID: "CVE-2025-0003", Severity: "MEDIUM", PackageName: "zlib", PackageVersion: "1.2.13", CVSSScore: 5.0},
+		},
+		SystemPackages: []domain.SystemPackage{
+			{Name: "openssl", Version: "3.0.1", PackageType: "rpm"},
+			{Name: "curl", Version: "7.88.0", PackageType: "rpm"},
+		},
+		PackageManagers: []domain.PackageManager{
+			{Name: "pip", Version: "24.0", Language: "python"},
+		},
+	}
+	require.NoError(t, repo.InsertImage(img))
+
+	outPath := filepath.Join(t.TempDir(), "detail.json")
+	require.NoError(t, GenerateDetailJSONReport(repo, outPath))
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	var report DetailJSONReport
+	require.NoError(t, json.Unmarshal(data, &report))
+
+	assert.Equal(t, 1, report.ImageCount)
+	assert.Equal(t, 1, report.SchemaVersion)
+	require.Len(t, report.Images, 1)
+
+	entry := report.Images[0]
+	assert.Equal(t, "mcr.microsoft.com/azurelinux/base/python:3.12", entry.Name)
+	assert.Equal(t, "mcr.microsoft.com", entry.Registry)
+	assert.Equal(t, "azurelinux/base/python", entry.Repository)
+	assert.Equal(t, "3.12", entry.Tag)
+	assert.Equal(t, "sha256:abc123", entry.Digest)
+	assert.Equal(t, int64(85000000), entry.SizeBytes)
+	assert.Equal(t, "81.1 MB", entry.SizeHuman)
+	assert.Equal(t, 5, entry.Layers)
+	assert.Equal(t, "2025-04-15T08:30:00Z", entry.CreatedDate)
+
+	assert.Equal(t, "Azure Linux", entry.BaseOS.Name)
+	assert.Equal(t, "3.0", entry.BaseOS.Version)
+
+	assert.Equal(t, 3, entry.VulnerabilitySummary.Total)
+	assert.Equal(t, 1, entry.VulnerabilitySummary.Critical)
+	assert.Equal(t, 1, entry.VulnerabilitySummary.High)
+	assert.Equal(t, 1, entry.VulnerabilitySummary.Medium)
+
+	require.Len(t, entry.Languages, 1)
+	assert.Equal(t, "python", entry.Languages[0].Language)
+	assert.Equal(t, "3.12.9", entry.Languages[0].Version)
+	assert.True(t, entry.Languages[0].Verified)
+
+	require.Len(t, entry.Vulnerabilities, 3)
+	assert.Equal(t, "CVE-2025-0001", entry.Vulnerabilities[0].ID)
+	assert.Equal(t, "CRITICAL", entry.Vulnerabilities[0].Severity)
+	assert.Equal(t, 9.8, entry.Vulnerabilities[0].CVSSScore)
+	assert.Equal(t, "3.0.2", entry.Vulnerabilities[0].FixedVersion)
+
+	require.Len(t, entry.SystemPackages, 2)
+	assert.Equal(t, "openssl", entry.SystemPackages[0].Name)
+
+	require.Len(t, entry.PackageManagers, 1)
+	assert.Equal(t, "pip", entry.PackageManagers[0].Name)
+}
+
+func TestGenerateDetailJSONReport_EmptyDB(t *testing.T) {
+	db, repo := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	outPath := filepath.Join(t.TempDir(), "detail.json")
+	require.NoError(t, GenerateDetailJSONReport(repo, outPath))
+
+	_, err := os.Stat(outPath)
+	assert.True(t, os.IsNotExist(err), "empty DB should not produce a detail report file")
+}
+
+func TestGenerateDetailJSONReport_EmptyDBRemovesStaleFile(t *testing.T) {
+	db, repo := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	outPath := filepath.Join(t.TempDir(), "detail.json")
+	require.NoError(t, os.WriteFile(outPath, []byte(`{"stale": true}`), 0o644))
+
+	require.NoError(t, GenerateDetailJSONReport(repo, outPath))
+
+	_, err := os.Stat(outPath)
+	assert.True(t, os.IsNotExist(err), "stale detail report should be removed when DB is empty")
+}
+
+func TestGenerateDetailJSONReport_MultipleImages(t *testing.T) {
+	db, repo := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	images := []domain.ImageRecord{
+		{
+			Name: "python-img:3.12", Registry: "r", Repository: "repo1", Tag: "3.12",
+			BaseOSName: "azurelinux", TotalVulnerabilities: 2,
+			Languages: []domain.Language{{Language: "python", Version: "3.12.9"}},
+			Vulnerabilities: []domain.Vulnerability{
+				{VulnerabilityID: "CVE-2025-1111", Severity: "HIGH", PackageName: "pkg1", PackageVersion: "1.0"},
+				{VulnerabilityID: "CVE-2025-1112", Severity: "LOW", PackageName: "pkg2", PackageVersion: "2.0"},
+			},
+			SystemPackages: []domain.SystemPackage{{Name: "pkg1", Version: "1.0"}},
+		},
+		{
+			Name: "go-img:1.21", Registry: "r", Repository: "repo2", Tag: "1.21",
+			BaseOSName: "azurelinux", TotalVulnerabilities: 0,
+			Languages:  []domain.Language{{Language: "go", Version: "1.21.0"}},
+		},
+	}
+
+	for i := range images {
+		require.NoError(t, repo.InsertImage(&images[i]))
+	}
+
+	outPath := filepath.Join(t.TempDir(), "detail.json")
+	require.NoError(t, GenerateDetailJSONReport(repo, outPath))
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	var report DetailJSONReport
+	require.NoError(t, json.Unmarshal(data, &report))
+
+	assert.Equal(t, 2, report.ImageCount)
+	require.Len(t, report.Images, 2)
+
+	// Images ordered by name
+	assert.Equal(t, "go-img:1.21", report.Images[0].Name)
+	assert.Equal(t, "python-img:3.12", report.Images[1].Name)
+
+	// Verify child data attaches to correct image
+	assert.Len(t, report.Images[0].Vulnerabilities, 0)
+	assert.Len(t, report.Images[0].Languages, 1)
+	assert.Equal(t, "go", report.Images[0].Languages[0].Language)
+
+	assert.Len(t, report.Images[1].Vulnerabilities, 2)
+	assert.Len(t, report.Images[1].SystemPackages, 1)
+}
+
+func TestGenerateDetailJSONReport_VulnSummaryCounts(t *testing.T) {
+	db, repo := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	img := &domain.ImageRecord{
+		Name: "test-img:1.0", Registry: "r", Repository: "repo", Tag: "1.0",
+		TotalVulnerabilities: 6, CriticalVulnerabilities: 1, HighVulnerabilities: 2,
+		MediumVulnerabilities: 1, LowVulnerabilities: 1, NegligibleVulnerabilities: 0,
+		UnknownVulnerabilities: 1,
+		Languages: []domain.Language{{Language: "python", Version: "3.12"}},
+	}
+	require.NoError(t, repo.InsertImage(img))
+
+	outPath := filepath.Join(t.TempDir(), "detail.json")
+	require.NoError(t, GenerateDetailJSONReport(repo, outPath))
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	var report DetailJSONReport
+	require.NoError(t, json.Unmarshal(data, &report))
+
+	require.Len(t, report.Images, 1)
+	summary := report.Images[0].VulnerabilitySummary
+	assert.Equal(t, 6, summary.Total)
+	assert.Equal(t, 1, summary.Critical)
+	assert.Equal(t, 2, summary.High)
+	assert.Equal(t, 1, summary.Medium)
+	assert.Equal(t, 1, summary.Low)
+	assert.Equal(t, 0, summary.Negligible)
+	assert.Equal(t, 1, summary.Unknown)
+}
+
+func TestGenerateDetailJSONReport_EmptyChildSlicesNotNull(t *testing.T) {
+	db, repo := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	img := &domain.ImageRecord{
+		Name: "minimal:1.0", Registry: "r", Repository: "repo", Tag: "1.0",
+		Languages: []domain.Language{{Language: "base", Version: "3.0"}},
+	}
+	require.NoError(t, repo.InsertImage(img))
+
+	outPath := filepath.Join(t.TempDir(), "detail.json")
+	require.NoError(t, GenerateDetailJSONReport(repo, outPath))
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	// Empty arrays should serialize as [] not null
+	content := string(data)
+	assert.Contains(t, content, `"vulnerabilities": []`)
+	assert.Contains(t, content, `"systemPackages": []`)
+	assert.Contains(t, content, `"packageManagers": []`)
+}
+
+func TestGenerateDetailJSONReport_CreatesOutputDir(t *testing.T) {
+	db, repo := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	img := &domain.ImageRecord{
+		Name: "test:1.0", Registry: "r", Repository: "repo", Tag: "1.0",
+		Languages: []domain.Language{{Language: "go", Version: "1.21"}},
+	}
+	require.NoError(t, repo.InsertImage(img))
+
+	outPath := filepath.Join(t.TempDir(), "nested", "dir", "detail.json")
+	require.NoError(t, GenerateDetailJSONReport(repo, outPath))
+
+	_, err := os.Stat(outPath)
+	assert.NoError(t, err, "output file should exist in newly created directory")
+}

--- a/pkg/usecase/pipeline.go
+++ b/pkg/usecase/pipeline.go
@@ -103,7 +103,17 @@ func (p *Pipeline) GenerateReport() error {
 
 	jsonPath := strings.TrimSuffix(p.config.OutputPath, ".md") + ".json"
 
-	return report.GenerateJSONReport(p.repo, jsonPath, p.config.TopNJSON, &p.repoCfg)
+	if err := report.GenerateJSONReport(p.repo, jsonPath, p.config.TopNJSON, &p.repoCfg); err != nil {
+		return err
+	}
+
+	if p.config.Detailed {
+		detailPath := strings.TrimSuffix(jsonPath, ".json") + "_detail.json"
+
+		return report.GenerateDetailJSONReport(p.repo, detailPath)
+	}
+
+	return nil
 }
 
 func (p *Pipeline) scanRepository(repo string, category string) error {

--- a/reportCmd.go
+++ b/reportCmd.go
@@ -67,5 +67,15 @@ func runReport(_ *cobra.Command, _ []string) error {
 
 	jsonPath := strings.TrimSuffix(flgOutputPath, ".md") + ".json"
 
-	return report.GenerateJSONReport(repo, jsonPath, flgTopNJSON, &repoCfg)
+	if err := report.GenerateJSONReport(repo, jsonPath, flgTopNJSON, &repoCfg); err != nil {
+		return err
+	}
+
+	if flgDetailed {
+		detailPath := strings.TrimSuffix(jsonPath, ".json") + "_detail.json"
+
+		return report.GenerateDetailJSONReport(repo, detailPath)
+	}
+
+	return nil
 }

--- a/rootCmd.go
+++ b/rootCmd.go
@@ -38,6 +38,7 @@ var (
 	flgUpdateExisting bool
 	flgVerbose        bool
 	flgDebug          bool
+	flgDetailed       bool
 )
 
 // NewRootCommand creates the root cobra command.
@@ -57,6 +58,7 @@ and generates a markdown report ranking images by security posture per language.
 	rootCmd.PersistentFlags().IntVar(&flgTopNJSON, "json-top-n", 20, "Number of top images per language per base OS in JSON report (0 = all)")
 	rootCmd.PersistentFlags().BoolVarP(&flgVerbose, "verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&flgDebug, "debug", "d", false, "Enable debug output")
+	rootCmd.PersistentFlags().BoolVar(&flgDetailed, "detailed", false, "Generate detailed per-image JSON report with packages and vulnerabilities")
 
 	rootCmd.AddCommand(NewScanCommand())
 	rootCmd.AddCommand(NewReportCommand())

--- a/scanCmd.go
+++ b/scanCmd.go
@@ -72,6 +72,7 @@ func runScan(cmd *cobra.Command, _ []string) error {
 		CleanupImages:     !flgNoCleanup,
 		UpdateExisting:    flgUpdateExisting,
 		Verbose:           flgVerbose,
+		Detailed:          flgDetailed,
 	}
 
 	repo := database.NewRepository(db)


### PR DESCRIPTION
## Summary

Adds a new `--detailed` flag that generates a separate `*_detail.json` report with per-image package inventories, vulnerability breakdowns, and detected languages/runtimes (Option 6 from #38).

## Changes

### New: Detailed JSON report generator
- **`pkg/infrastructure/report/json_detail.go`** — structs and `GenerateDetailJSONReport()` producing a flat image list with nested vulnerabilities, system packages, package managers, and languages
- **`pkg/infrastructure/database/repository.go`** — `QueryAllImageDetails()` using batched eager loading within a read transaction for snapshot consistency
- **`pkg/infrastructure/report/json_detail_test.go`** — 7 tests covering full image detail, empty DB, multi-image child data correctness, vuln summary counts, empty array serialization, stale file cleanup, and output directory creation

### CLI wiring
- **`rootCmd.go`** — new `--detailed` persistent flag
- **`scanCmd.go`** / **`reportCmd.go`** / **`pkg/usecase/pipeline.go`** — flag threaded through both `sbi scan` and `sbi report` code paths

### Documentation
- **`docs/detailed-report.md`** (new) — full schema reference, optional-field notes, scope clarification, and 7 jq query examples
- **`README.md`** — flag in tables, usage example, link to detailed doc
- **`AGENTS.md`** — updated repo structure, key flags, and report section

### Other
- **`.gitattributes`** — Git LFS tracking for `docs/*_detail.json`
- **`pkg/domain/models.go`** — `Detailed bool` added to `ScanConfig`
- Report includes `schemaVersion: 1` for forward compatibility
- Empty arrays serialize as `[]` (not null)
- Stale detail files removed when DB is empty

## Design decisions
- **Opt-in via flag** — default report generation unchanged
- **All images** included (not top-N filtered) for full drill-down analysis
- **Batched eager loading** in a read transaction avoids SQLite single-connection issues
- **Separate file** — existing summary JSON untouched

Closes #38