### PR TITLE
Exclude date-stamped historical tags from default scans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ Generate reports:
   "tagFilter": {
     "skipExact": ["latest", "dev", "nightly"],
     "excludeKeywords": ["debug", "test", "experimental", "arm", "amd", "azl"],
-    "excludePatterns": ["(?i)[-.]?(alpha|beta|rc|preview)..."],
+    "excludePatterns": ["(?i)[-.]?(alpha|beta|rc|preview)...", "^\\d+\\.\\d+\\.\\d{8}$"],
     "requireDigit": true
   },
   "repositories": [
@@ -149,6 +149,7 @@ Generate reports:
 - **No colon** -> repository: tags are discovered via `GET /v2/{repo}/tags/list`, then filtered
 - **Has colon** -> single image: scanned directly, no tag discovery
 - **`"category": "base"`** -> marks a group as containing minimal/no-runtime images. During scanning, images in these groups that have no detected language runtime receive a synthetic `"base"` language entry, so they appear in a **"Base / No Runtime"** report section. Images in the group that do have detected languages are unaffected.
+- Default tag filtering excludes date-stamped historical build tags such as `3.0.20250206`; remove `^\\d+\\.\\d+\\.\\d{8}$` from a custom config to scan historical tags.
 
 ## Language Detection (3-stage pipeline)
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ The `tagFilter` section controls which discovered tags are included:
 | `excludePatterns` | Skip tags matching these regex patterns | `["(?i)[-.]?(alpha\|beta)"]` |
 | `requireDigit` | Only include tags that contain a digit | `true` |
 
+By default, `excludePatterns` skips pre-release tags and date-stamped historical build tags such as `3.0.20250206`. If you need historical comparisons, remove the date-stamped pattern from a custom config.
+
 ### Full config example
 
 ```json
@@ -127,7 +129,10 @@ The `tagFilter` section controls which discovered tags are included:
   "tagFilter": {
     "skipExact": ["latest", "dev", "nightly", "edge"],
     "excludeKeywords": ["debug", "test", "arm", "amd"],
-    "excludePatterns": ["(?i)[-.]?(alpha|beta|rc|preview)[\\d.]*$"],
+    "excludePatterns": [
+      "(?i)[-.]?(alpha|beta|rc|preview)[\\d.]*$",
+      "^\\d+\\.\\d+\\.\\d{8}$"
+    ],
     "requireDigit": true
   },
   "repositories": [

--- a/config/repositories.json
+++ b/config/repositories.json
@@ -6,7 +6,10 @@
   "tagFilter": {
     "skipExact": ["latest", "dev", "nightly", "edge", "rc", "beta", "alpha"],
     "excludeKeywords": ["debug", "test", "experimental", "arm", "amd", "azl"],
-    "excludePatterns": ["(?i)[-.]?(alpha|beta|rc|preview|dev|nightly|canary)[\\d.]*$"],
+    "excludePatterns": [
+      "(?i)[-.]?(alpha|beta|rc|preview|dev|nightly|canary)[\\d.]*$",
+      "^\\d+\\.\\d+\\.\\d{8}$"
+    ],
     "requireDigit": true
   },
   "repositories": [

--- a/config/smoke-test/repositories.json
+++ b/config/smoke-test/repositories.json
@@ -6,7 +6,10 @@
   "tagFilter": {
     "skipExact": ["latest", "dev", "nightly", "edge", "rc", "beta", "alpha"],
     "excludeKeywords": ["debug", "test", "experimental", "arm", "amd", "azl"],
-    "excludePatterns": ["(?i)[-.]?(alpha|beta|rc|preview|dev|nightly|canary)[\\d.]*$"],
+    "excludePatterns": [
+      "(?i)[-.]?(alpha|beta|rc|preview|dev|nightly|canary)[\\d.]*$",
+      "^\\d+\\.\\d+\\.\\d{8}$"
+    ],
     "requireDigit": true
   },
   "repositories": [

--- a/pkg/infrastructure/scanner/analyzer_test.go
+++ b/pkg/infrastructure/scanner/analyzer_test.go
@@ -30,17 +30,21 @@ import (
 
 func TestFilterTags(t *testing.T) {
 	tags := []string{"3.12", "3.11", "3.12-rc1", "3.11-beta", "3.10-alpha", "latest", "3.12-preview",
-		"3.12.9-8-azl3.0.20260204-arm64", "3.12.9-8-azl3.0.20260204-amd64", "3.12.9-8-debug-nonroot"}
+		"3.0.20250206", "3.12.9", "10.0.19041", "3.12.9-8-azl3.0.20260204-arm64", "3.12.9-8-azl3.0.20260204-amd64",
+		"3.12.9-8-debug-nonroot"}
 	filtered := FilterTags(tags, DefaultTagFilter())
 
 	assert.Contains(t, filtered, "3.12")
 	assert.Contains(t, filtered, "3.11")
+	assert.Contains(t, filtered, "3.12.9")
+	assert.Contains(t, filtered, "10.0.19041")
 	assert.NotContains(t, filtered, "latest")
 	assert.NotContains(t, filtered, "3.12-rc1")
 	assert.NotContains(t, filtered, "3.11-beta")
 	assert.NotContains(t, filtered, "3.10-alpha")
 	assert.NotContains(t, filtered, "3.12-preview")
-	// Arch-specific and build-specific tags should be excluded
+	assert.NotContains(t, filtered, "3.0.20250206")
+	// Arch-specific, dated, and build-specific tags should be excluded
 	assert.NotContains(t, filtered, "3.12.9-8-azl3.0.20260204-arm64")
 	assert.NotContains(t, filtered, "3.12.9-8-azl3.0.20260204-amd64")
 	assert.NotContains(t, filtered, "3.12.9-8-debug-nonroot")

--- a/pkg/infrastructure/scanner/registry.go
+++ b/pkg/infrastructure/scanner/registry.go
@@ -40,7 +40,7 @@ func DefaultTagFilter() domain.TagFilterConfig {
 	return domain.TagFilterConfig{
 		SkipExact:       []string{"latest", "dev", "nightly", "edge", "rc", "beta", "alpha"},
 		ExcludeKeywords: []string{"debug", "test", "experimental", "arm", "amd", "azl"},
-		ExcludePatterns: []string{`(?i)[-.]?(alpha|beta|rc|preview|dev|nightly|canary)[\d.]*$`},
+		ExcludePatterns: []string{`(?i)[-.]?(alpha|beta|rc|preview|dev|nightly|canary)[\d.]*$`, `^\d+\.\d+\.\d{8}$`},
 		RequireDigit:    true,
 	}
 }


### PR DESCRIPTION
## Summary

- Exclude historical date-stamped tags like `3.0.20250206` from the default discovered-tag filter
- Apply the same default in main and smoke-test repository configs
- Document the default behavior and how to re-enable historical tags with custom config
- Add scanner test coverage that preserves normal version tags while filtering dated builds

## Validation

- `go test ./pkg/infrastructure/scanner`
- `task lint`

Closes #41