### PR TITLE
fix: generate detailed JSON report in nightly scan

### DIFF
--- a/.github/nightly-allowed-files.sh
+++ b/.github/nightly-allowed-files.sh
@@ -5,4 +5,5 @@ NIGHTLY_ALLOWED_FILES=(
   "azure_linux_images.db"
   "docs/daily_recommendations.md"
   "docs/daily_recommendations.json"
+  "docs/daily_recommendations_detail.json"
 )

--- a/.github/workflows/nightly-scan.yml
+++ b/.github/workflows/nightly-scan.yml
@@ -85,6 +85,7 @@ jobs:
             --max-tags 0 \
             --comprehensive \
             --update-existing \
+            --detailed \
             -v
 
       - name: 📊 Show database stats


### PR DESCRIPTION
## Summary

Add the `--detailed` flag to the nightly scan workflow so `docs/daily_recommendations_detail.json` is generated alongside the existing markdown and JSON reports.

## Changes

- **`.github/workflows/nightly-scan.yml`** — add `--detailed` to the `sbi scan` invocation
- **`.github/nightly-allowed-files.sh`** — add `docs/daily_recommendations_detail.json` to the nightly output allowlist so the commit validation accepts the new artifact

## Context

The CLI already supports `--detailed` and locally produces the report correctly. The nightly workflow simply wasn't passing the flag, and the allowlist would have rejected the file as unexpected output.

Fixes #45