### PR TITLE
Fix devcontainer setup: executable script, pinned versions, and lockfile

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+    },
+    "ghcr.io/eitsupi/devcontainer-features/go-task:1": {
+      "version": "1.0.4",
+      "resolved": "ghcr.io/eitsupi/devcontainer-features/go-task@sha256:8a6c4b4f9d7559f32400da0c11d1bb11e59732f47f7db5defca68e7712544d13",
+      "integrity": "sha256:8a6c4b4f9d7559f32400da0c11d1bb11e59732f47f7db5defca68e7712544d13"
+    },
+    "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
+      "version": "2.1.1",
+      "resolved": "ghcr.io/eitsupi/devcontainer-features/jq-likes@sha256:6a8b044f9f424097ec6d212167836b26994a76a556cbcb202084be79fe8032bd",
+      "integrity": "sha256:6a8b044f9f424097ec6d212167836b26994a76a556cbcb202084be79fe8032bd"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,8 +8,8 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/eitsupi/devcontainer-features/go-task:1": {},
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
-      "jqVersion": "latest",
-      "yqVersion": "latest"
+      "jqVersion": "1.8.1",
+      "yqVersion": "v4.53.2"
     }
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",

--- a/.devcontainer/install-tools.sh
+++ b/.devcontainer/install-tools.sh
@@ -8,6 +8,41 @@ source "${SCRIPT_DIR}/../.github/tool-versions.sh"
 
 echo "=== Installing scanning tools ==="
 
+# GitHub and Git LFS tooling used for issue/PR workflows in the dev container
+echo "Installing GitHub CLI and Git LFS..."
+ARCH="$(dpkg --print-architecture)"
+case "${ARCH}" in
+	amd64|arm64)
+		;;
+	*)
+		echo "Unsupported architecture: ${ARCH}" >&2
+		exit 1
+		;;
+esac
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+GH_VERSION_NO_V="${GH_VERSION#v}"
+GH_TARBALL="${TMP_DIR}/gh.tar.gz"
+curl -sSfL -o "${GH_TARBALL}" \
+	"https://github.com/cli/cli/releases/download/${GH_VERSION}/gh_${GH_VERSION_NO_V}_linux_${ARCH}.tar.gz"
+tar -xzf "${GH_TARBALL}" -C "${TMP_DIR}"
+sudo install -m 0755 "${TMP_DIR}/gh_${GH_VERSION_NO_V}_linux_${ARCH}/bin/gh" /usr/local/bin/gh
+
+GIT_LFS_VERSION_NO_V="${GIT_LFS_VERSION#v}"
+GIT_LFS_TARBALL="${TMP_DIR}/git-lfs.tar.gz"
+curl -sSfL -o "${GIT_LFS_TARBALL}" \
+	"https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-${ARCH}-v${GIT_LFS_VERSION_NO_V}.tar.gz"
+tar -xzf "${GIT_LFS_TARBALL}" -C "${TMP_DIR}"
+GIT_LFS_DIR="$(find "${TMP_DIR}" -maxdepth 1 -type d -name 'git-lfs-*' | head -n 1)"
+if [[ -z "${GIT_LFS_DIR}" ]]; then
+	echo "Failed to locate extracted git-lfs directory" >&2
+	exit 1
+fi
+sudo bash "${GIT_LFS_DIR}/install.sh"
+sudo git lfs install --system
+
 # Syft (SBOM generator)
 echo "Installing Syft..."
 curl -sSfL "https://raw.githubusercontent.com/anchore/syft/${SYFT_INSTALLER_SHA}/install.sh" | sudo sh -s -- -b /usr/local/bin "${SYFT_VERSION}"
@@ -21,6 +56,8 @@ echo "Installing golangci-lint..."
 curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCI_LINT_INSTALLER_SHA}/install.sh" | sudo sh -s -- -b /usr/local/bin "${GOLANGCI_LINT_VERSION}"
 
 echo "=== Tools installed ==="
+gh --version
+git lfs version
 syft version
 trivy version
 golangci-lint version

--- a/.github/tool-versions.sh
+++ b/.github/tool-versions.sh
@@ -9,3 +9,6 @@ TRIVY_INSTALLER_SHA="6fb20c8edd70745d6b34bff0387b53b03c8a760a" # aquasecurity/tr
 
 GOLANGCI_LINT_VERSION="v2.11.4"
 GOLANGCI_LINT_INSTALLER_SHA="8f3b0c7ed018e57905fbd873c697e0b1ede605a5" # golangci/golangci-lint install.sh
+
+GH_VERSION="v2.75.1"
+GIT_LFS_VERSION="v3.7.0"


### PR DESCRIPTION
## Summary
Fix devcontainer startup reliability and tool availability.

Closes #49.

## Changes
- Make .devcontainer/install-tools.sh executable.
- Pin jq/yq feature versions in .devcontainer/devcontainer.json.
- Add GH_VERSION and GIT_LFS_VERSION to .github/tool-versions.sh.
- Install gh and git-lfs in .devcontainer/install-tools.sh.
- Add .devcontainer/devcontainer-lock.json for deterministic feature resolution.

## Validation
- Branch: fix/devcontainer-tools-permissions
- Commit includes only the 4 intended files.
