### PR TITLE
fix: sort image tags with version-aware newest-first ordering

### DIFF
--- a/pkg/infrastructure/scanner/analyzer_test.go
+++ b/pkg/infrastructure/scanner/analyzer_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFilterTags(t *testing.T) {
@@ -48,6 +49,83 @@ func TestFilterTags(t *testing.T) {
 	assert.NotContains(t, filtered, "3.12.9-8-azl3.0.20260204-arm64")
 	assert.NotContains(t, filtered, "3.12.9-8-azl3.0.20260204-amd64")
 	assert.NotContains(t, filtered, "3.12.9-8-debug-nonroot")
+}
+
+func TestFilterTags_VersionAwareNewestFirst(t *testing.T) {
+	// Reverse string sort would put 9.0 before 10.0; version-aware sort must not.
+	tags := []string{"1.26", "1.25", "10.0", "9.0", "8.0", "2.0"}
+	filtered := FilterTags(tags, DefaultTagFilter())
+
+	require.Equal(t, []string{"10.0", "9.0", "8.0", "2.0", "1.26", "1.25"}, filtered)
+
+	// With max-tags, the newest majors must be selected (not 9.x/8.x only).
+	assert.Equal(t, []string{"10.0", "9.0", "8.0"}, LimitTags(filtered, 3))
+}
+
+func TestSortTagsNewestFirst(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "major versions not lexical",
+			input: []string{"9.0", "10.0", "8.0"},
+			want:  []string{"10.0", "9.0", "8.0"},
+		},
+		{
+			name:  "patch vs minor",
+			input: []string{"3.12", "3.12.9", "3.11"},
+			want:  []string{"3.12.9", "3.12", "3.11"},
+		},
+		{
+			name:  "suffix after version",
+			input: []string{"8.0-noble", "10.0-azurelinux3.0", "9.0"},
+			want:  []string{"10.0-azurelinux3.0", "9.0", "8.0-noble"},
+		},
+		{
+			name:  "single segment",
+			input: []string{"21", "25", "17"},
+			want:  []string{"25", "21", "17"},
+		},
+		{
+			name:  "equal version different suffix",
+			input: []string{"8.0-noble", "8.0-azurelinux3.0"},
+			// Ascending rest: "-azurelinux3.0" < "-noble"; newest-first reverses that.
+			want: []string{"8.0-noble", "8.0-azurelinux3.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := append([]string(nil), tt.input...)
+			sortTagsNewestFirst(got)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVersionPrefix(t *testing.T) {
+	tests := []struct {
+		tag      string
+		wantSegs []int
+		wantRest string
+	}{
+		{"10.0", []int{10, 0}, ""},
+		{"10.0-noble", []int{10, 0}, "-noble"},
+		{"3.12.9", []int{3, 12, 9}, ""},
+		{"21-azurelinux", []int{21}, "-azurelinux"},
+		{"latest", nil, "latest"},
+		{"", nil, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			segs, rest := versionPrefix(tt.tag)
+			assert.Equal(t, tt.wantSegs, segs)
+			assert.Equal(t, tt.wantRest, rest)
+		})
+	}
 }
 
 func TestLimitTags(t *testing.T) {

--- a/pkg/infrastructure/scanner/analyzer_test.go
+++ b/pkg/infrastructure/scanner/analyzer_test.go
@@ -62,6 +62,16 @@ func TestFilterTags_VersionAwareNewestFirst(t *testing.T) {
 	assert.Equal(t, []string{"10.0", "9.0", "8.0"}, LimitTags(filtered, 3))
 }
 
+func TestFilterTags_VPrefixedVersionAwareNewestFirst(t *testing.T) {
+	// Reverse string sort ranks v9.0 above v10.0; version-aware sort must not.
+	// These tags pass RequireDigit and must keep numeric major ordering under --max-tags.
+	tags := []string{"v1.26", "v1.25", "v10.0", "v9.0", "v8.0", "v2.0"}
+	filtered := FilterTags(tags, DefaultTagFilter())
+
+	require.Equal(t, []string{"v10.0", "v9.0", "v8.0", "v2.0", "v1.26", "v1.25"}, filtered)
+	assert.Equal(t, []string{"v10.0", "v9.0", "v8.0"}, LimitTags(filtered, 3))
+}
+
 func TestSortTagsNewestFirst(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -74,6 +84,16 @@ func TestSortTagsNewestFirst(t *testing.T) {
 			want:  []string{"10.0", "9.0", "8.0"},
 		},
 		{
+			name:  "v-prefixed majors not lexical",
+			input: []string{"v9.0", "v10.0", "v8.0"},
+			want:  []string{"v10.0", "v9.0", "v8.0"},
+		},
+		{
+			name:  "mixed bare and v-prefixed majors",
+			input: []string{"v9.0", "10.0", "v8.0"},
+			want:  []string{"10.0", "v9.0", "v8.0"},
+		},
+		{
 			name:  "patch vs minor",
 			input: []string{"3.12", "3.12.9", "3.11"},
 			want:  []string{"3.12.9", "3.12", "3.11"},
@@ -82,6 +102,11 @@ func TestSortTagsNewestFirst(t *testing.T) {
 			name:  "suffix after version",
 			input: []string{"8.0-noble", "10.0-azurelinux3.0", "9.0"},
 			want:  []string{"10.0-azurelinux3.0", "9.0", "8.0-noble"},
+		},
+		{
+			name:  "v-prefixed with suffix",
+			input: []string{"v8.0-noble", "v10.0-azurelinux3.0", "v9.0"},
+			want:  []string{"v10.0-azurelinux3.0", "v9.0", "v8.0-noble"},
 		},
 		{
 			name:  "single segment",
@@ -113,9 +138,15 @@ func TestVersionPrefix(t *testing.T) {
 	}{
 		{"10.0", []int{10, 0}, ""},
 		{"10.0-noble", []int{10, 0}, "-noble"},
+		{"v10.0", []int{10, 0}, ""},
+		{"V10.0", []int{10, 0}, ""},
+		{"v10.0-noble", []int{10, 0}, "-noble"},
+		{"v9.0", []int{9, 0}, ""},
 		{"3.12.9", []int{3, 12, 9}, ""},
 		{"21-azurelinux", []int{21}, "-azurelinux"},
 		{"latest", nil, "latest"},
+		{"version", nil, "version"}, // leading 'v' but not a version prefix
+		{"v", nil, "v"},
 		{"", nil, ""},
 	}
 

--- a/pkg/infrastructure/scanner/registry.go
+++ b/pkg/infrastructure/scanner/registry.go
@@ -211,10 +211,20 @@ func tagVersionLess(a, b string) bool {
 }
 
 // versionPrefix parses the leading numeric version from a tag.
-// Examples: "10.0-noble" → ([10, 0], "-noble"), "3.12.9" → ([3, 12, 9], ""),
-// "21-azurelinux" → ([21], "-azurelinux"), "latest" → (nil, "latest").
+// An optional conventional "v"/"V" prefix is skipped when immediately followed
+// by a digit (e.g. "v10.0" is treated like "10.0"), so version-aware sort does
+// not regress to reverse-lexicographic order for v-prefixed tags.
+// Examples: "10.0-noble" → ([10, 0], "-noble"), "v10.0" → ([10, 0], ""),
+// "3.12.9" → ([3, 12, 9], ""), "21-azurelinux" → ([21], "-azurelinux"),
+// "latest" → (nil, "latest").
 func versionPrefix(tag string) (segs []int, rest string) {
 	i := 0
+	// Skip optional conventional version prefix only when a digit follows
+	// (so "version" / "vv1" are not misparsed as versions).
+	if len(tag) >= 2 && (tag[0] == 'v' || tag[0] == 'V') && tag[1] >= '0' && tag[1] <= '9' {
+		i = 1
+	}
+
 	for i < len(tag) {
 		if tag[i] < '0' || tag[i] > '9' {
 			break
@@ -233,6 +243,12 @@ func versionPrefix(tag string) (segs []int, rest string) {
 		}
 
 		break
+	}
+
+	if len(segs) == 0 {
+		// No version parsed — return the original tag as rest (including any
+		// leading character we may have peeked but not treated as a prefix).
+		return nil, tag
 	}
 
 	return segs, tag[i:]

--- a/pkg/infrastructure/scanner/registry.go
+++ b/pkg/infrastructure/scanner/registry.go
@@ -152,10 +152,90 @@ func FilterTags(tags []string, cfg domain.TagFilterConfig) []string {
 		filtered = append(filtered, tag)
 	}
 
-	// Sort descending (newest first assuming semver-like ordering)
-	sort.Sort(sort.Reverse(sort.StringSlice(filtered)))
+	// Sort newest-first with version-aware ordering so LimitTags keeps
+	// higher releases (e.g. 10.0 before 9.0), not reverse lexicographic order.
+	sortTagsNewestFirst(filtered)
 
 	return filtered
+}
+
+// sortTagsNewestFirst sorts tags descending by leading numeric version
+// (major.minor.patch…), then by the remaining suffix. Tags without a leading
+// version number sort last.
+func sortTagsNewestFirst(tags []string) {
+	sort.SliceStable(tags, func(i, j int) bool {
+		// Descending: i before j when j < i in ascending version order.
+		return tagVersionLess(tags[j], tags[i])
+	})
+}
+
+// tagVersionLess reports whether a sorts before b in ascending version order.
+func tagVersionLess(a, b string) bool {
+	aSegs, aRest := versionPrefix(a)
+	bSegs, bRest := versionPrefix(b)
+
+	// Non-version tags sort before versioned tags in ascending order so they
+	// appear last when sorted newest-first.
+	switch {
+	case len(aSegs) == 0 && len(bSegs) == 0:
+		return a < b
+	case len(aSegs) == 0:
+		return true
+	case len(bSegs) == 0:
+		return false
+	}
+
+	n := len(aSegs)
+	if len(bSegs) > n {
+		n = len(bSegs)
+	}
+
+	for i := 0; i < n; i++ {
+		av, bv := 0, 0
+		if i < len(aSegs) {
+			av = aSegs[i]
+		}
+		if i < len(bSegs) {
+			bv = bSegs[i]
+		}
+		if av != bv {
+			return av < bv
+		}
+	}
+
+	if aRest != bRest {
+		return aRest < bRest
+	}
+
+	return a < b
+}
+
+// versionPrefix parses the leading numeric version from a tag.
+// Examples: "10.0-noble" → ([10, 0], "-noble"), "3.12.9" → ([3, 12, 9], ""),
+// "21-azurelinux" → ([21], "-azurelinux"), "latest" → (nil, "latest").
+func versionPrefix(tag string) (segs []int, rest string) {
+	i := 0
+	for i < len(tag) {
+		if tag[i] < '0' || tag[i] > '9' {
+			break
+		}
+
+		n := 0
+		for i < len(tag) && tag[i] >= '0' && tag[i] <= '9' {
+			n = n*10 + int(tag[i]-'0')
+			i++
+		}
+		segs = append(segs, n)
+
+		if i < len(tag) && tag[i] == '.' && i+1 < len(tag) && tag[i+1] >= '0' && tag[i+1] <= '9' {
+			i++ // consume dot between version segments
+			continue
+		}
+
+		break
+	}
+
+	return segs, tag[i:]
 }
 
 // LimitTags returns at most maxTags tags. If maxTags is 0, all tags are returned.


### PR DESCRIPTION
﻿## Summary

- Replace reverse lexicographic tag sort in `FilterTags` with version-aware newest-first ordering
- Leading numeric segments (`major.minor.patch…`) are compared so `10.0` ranks above `9.0`
- Ensures `--max-tags` / `LimitTags` keeps the newest releases instead of dropping them

Fixes #66

## Test plan

- [x] `go test ./pkg/infrastructure/scanner/ -count=1`
- [x] New tests: `TestFilterTags_VersionAwareNewestFirst`, `TestSortTagsNewestFirst`, `TestVersionPrefix`
- [x] Existing `TestFilterTags` / `TestLimitTags` still pass
