### PR TITLE
fix: treat v-prefixed tags as numeric in digest dedup specificity

### DIFF
--- a/pkg/infrastructure/report/dedup.go
+++ b/pkg/infrastructure/report/dedup.go
@@ -95,28 +95,36 @@ func DeduplicateByDigest(images []domain.RecommendedImage) []domain.RecommendedI
 // tagSpecificity scores how specific an image tag is.
 // Higher score = more specific. Prefers numeric version tags over
 // non-numeric ones, then counts dot-separated version segments.
+// Optional conventional "v"/"V" prefixes (when followed by a digit) are treated
+// as numeric, consistent with version-aware tag sorting.
 func tagSpecificity(name string) int {
 	tag := extractTag(name)
 	if tag == "" {
 		return 0
 	}
 
-	// Tags starting with a digit are strongly preferred over non-numeric tags
-	// (e.g., "3.12" should always beat "latest").
+	// Normalize optional v/V prefix so "v10.0" is scored like a numeric tag.
+	versionTag := tag
+	if len(tag) >= 2 && (tag[0] == 'v' || tag[0] == 'V') && tag[1] >= '0' && tag[1] <= '9' {
+		versionTag = tag[1:]
+	}
+
+	// Tags with a leading digit (after optional v-prefix) are strongly preferred
+	// over non-numeric tags (e.g., "3.12" / "v3.12" should beat "latest").
 	numericBonus := 0
-	if len(tag) > 0 && tag[0] >= '0' && tag[0] <= '9' {
+	if len(versionTag) > 0 && versionTag[0] >= '0' && versionTag[0] <= '9' {
 		numericBonus = 10000
 	}
 
 	// Extract the leading version portion (before any '-' suffix like "-nonroot").
-	versionPart := tag
-	if idx := strings.IndexByte(tag, '-'); idx > 0 {
-		versionPart = tag[:idx]
+	versionPart := versionTag
+	if idx := strings.IndexByte(versionTag, '-'); idx > 0 {
+		versionPart = versionTag[:idx]
 	}
 
 	segments := strings.Count(versionPart, ".") + 1
 
-	// Use numericBonus + segments * 1000 + tag length for tie-breaking.
+	// Use numericBonus + segments * 1000 + original tag length for tie-breaking.
 	return numericBonus + segments*1000 + len(tag)
 }
 

--- a/pkg/infrastructure/report/dedup_test.go
+++ b/pkg/infrastructure/report/dedup_test.go
@@ -183,20 +183,39 @@ func TestDeduplicateByDigest_PreservesOrder(t *testing.T) {
 
 func TestTagSpecificity(t *testing.T) {
 	tests := []struct {
-		name     string
-		less     string
-		more     string
+		name string
+		less string
+		more string
 	}{
 		{"major vs major.minor", "mcr.microsoft.com/repo:3", "mcr.microsoft.com/repo:3.12"},
 		{"major.minor vs major.minor.patch", "mcr.microsoft.com/repo:24.14", "mcr.microsoft.com/repo:24.14.1"},
 		{"with suffix", "mcr.microsoft.com/repo:24-nonroot", "mcr.microsoft.com/repo:24.14-nonroot"},
+		{"v-prefix vs older bare major", "mcr.microsoft.com/repo:9.0", "mcr.microsoft.com/repo:v10.0"},
+		{"v-prefix vs latest", "mcr.microsoft.com/repo:latest", "mcr.microsoft.com/repo:v3.12"},
+		{"v major.minor vs v major", "mcr.microsoft.com/repo:v3", "mcr.microsoft.com/repo:v3.12"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Greater(t, tagSpecificity(tt.more), tagSpecificity(tt.less))
+			assert.Greater(t, tagSpecificity(tt.more), tagSpecificity(tt.less),
+				"specificity(%s)=%d specificity(%s)=%d",
+				tt.more, tagSpecificity(tt.more), tt.less, tagSpecificity(tt.less))
 		})
 	}
+}
+
+func TestDeduplicateByDigest_VPrefixedNumericPreferred(t *testing.T) {
+	// Bare "9.0" must not outrank "v10.0" solely because the latter starts with 'v'.
+	images := []domain.RecommendedImage{
+		{Name: "mcr.microsoft.com/repo:9.0", Digest: "sha256:aaa"},
+		{Name: "mcr.microsoft.com/repo:v10.0", Digest: "sha256:aaa"},
+	}
+
+	result := DeduplicateByDigest(images)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "mcr.microsoft.com/repo:v10.0", result[0].Name)
+	assert.Equal(t, []string{":9.0"}, result[0].AlternateTags)
 }
 
 func TestExtractTag(t *testing.T) {


### PR DESCRIPTION
## Description `tagSpecificity` (used by digest dedup) only awarded a numeric bonus when the tag started with a digit, so `9.0` outranked `v10.0` as the primary recommendation. Align with version-aware tag sorting (#68).  ## Related Issue Fixes #75  ## Changes - Skip optional `v`/`V` prefix when followed by a digit before scoring - Regression tests for specificity and `DeduplicateByDigest`  ## Checklist - [x] `task lint` passes locally - [x] `task test` passes locally - [x] Documentation updated (if applicable)

---
### Stacking
Independent of the Trivy/registry stacks — can merge in any order relative to them.
