### PR TITLE
fix: return error from ScanAll when every scan attempt fails

### DIFF
--- a/pkg/usecase/pipeline.go
+++ b/pkg/usecase/pipeline.go
@@ -35,13 +35,21 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type imageAnalyzer interface {
+	Analyze(imageName string) (*domain.ImageAnalysis, error)
+}
+
+type tagDiscoverer interface {
+	GetTags(repo string) ([]string, error)
+}
+
 // Pipeline orchestrates the full scan and report generation workflow.
 type Pipeline struct {
 	config   domain.ScanConfig
 	repoCfg  domain.RepositoryConfig
 	repo     *database.Repository
-	analyzer *scanner.ImageAnalyzer
-	registry *scanner.RegistryScanner
+	analyzer imageAnalyzer
+	registry tagDiscoverer
 }
 
 // NewPipeline creates a new Pipeline.
@@ -85,10 +93,11 @@ func (s *scanStats) result() error {
 	return nil
 }
 
-// record counts a real scan attempt. Images skipped because they already
-// exist and --update-existing is unset are not attempts.
+// record counts a real scan attempt. A clean skip (already in the DB,
+// --update-existing unset) is not an attempt. A skip paired with an error
+// is treated as a failed attempt so a caller cannot hide a failure.
 func (s *scanStats) record(skipped bool, err error) {
-	if skipped {
+	if skipped && err == nil {
 		return
 	}
 	s.attempted++
@@ -187,7 +196,7 @@ func (p *Pipeline) scanRepository(repo string, category string, stats *scanStats
 	}
 }
 
-func (p *Pipeline) scanSingleImage(imageName string, category string) (skipped bool, err error) {
+func (p *Pipeline) scanSingleImage(imageName string, category string) (bool, error) {
 	if !p.config.UpdateExisting {
 		exists, err := p.repo.ImageExists(imageName)
 		if err != nil {

--- a/pkg/usecase/pipeline.go
+++ b/pkg/usecase/pipeline.go
@@ -68,26 +68,57 @@ func NewPipeline(config domain.ScanConfig, repo *database.Repository) (*Pipeline
 	}, nil
 }
 
+// scanStats tracks per-operation outcomes for ScanAll.
+type scanStats struct {
+	attempted int
+	failed    int
+}
+
+// result returns an error when every attempt failed. Partial failure is OK.
+func (s *scanStats) result() error {
+	if s.attempted == 0 {
+		return nil
+	}
+	if s.failed == s.attempted {
+		return fmt.Errorf("all %d scan operations failed", s.attempted)
+	}
+	return nil
+}
+
 // ScanAll loads repositories from config, discovers tags, and scans all images.
+// Individual image failures are logged and scanning continues. Returns an error
+// only when every scan attempt failed (total outage), so partial success still
+// allows report generation from newly scanned images.
 func (p *Pipeline) ScanAll() error {
+	stats := &scanStats{}
+
 	for _, group := range p.repoCfg.Repositories {
 		repos, singleImages := scanner.ParseImagePatterns(group.Images)
 		log.Infof("Group %q: %d repositories, %d single images", group.Description, len(repos), len(singleImages))
 
 		for _, repo := range repos {
-			if err := p.scanRepository(repo, group.Category); err != nil {
-				log.Errorf("Error scanning repository %s: %v", repo, err)
-			}
+			p.scanRepository(repo, group.Category, stats)
 		}
 
 		for _, img := range singleImages {
+			stats.attempted++
 			if err := p.scanSingleImage(img, group.Category); err != nil {
+				stats.failed++
 				log.Errorf("Error scanning image %s: %v", img, err)
 			}
 		}
 	}
 
-	return nil
+	if stats.attempted == 0 {
+		log.Warn("No scan operations were attempted")
+		return nil
+	}
+
+	if stats.failed > 0 && stats.failed < stats.attempted {
+		log.Warnf("Scan completed with %d/%d failures", stats.failed, stats.attempted)
+	}
+
+	return stats.result()
 }
 
 // ScanImage scans a single image by name.
@@ -116,12 +147,16 @@ func (p *Pipeline) GenerateReport() error {
 	return nil
 }
 
-func (p *Pipeline) scanRepository(repo string, category string) error {
+func (p *Pipeline) scanRepository(repo string, category string, stats *scanStats) {
 	log.Infof("Scanning repository: %s", repo)
 
 	tags, err := p.registry.GetTags(repo)
 	if err != nil {
-		return fmt.Errorf("getting tags for %s: %w", repo, err)
+		// Count tag discovery failure as a single failed attempt for this repo.
+		stats.attempted++
+		stats.failed++
+		log.Errorf("Error scanning repository %s: getting tags: %v", repo, err)
+		return
 	}
 
 	filtered := scanner.FilterTags(tags, p.repoCfg.TagFilter)
@@ -132,13 +167,12 @@ func (p *Pipeline) scanRepository(repo string, category string) error {
 	defaultRegistry := p.repoCfg.Defaults.Registry
 	for _, tag := range limited {
 		imageName := scanner.BuildFullImageName(defaultRegistry, repo, tag)
-
+		stats.attempted++
 		if err := p.scanSingleImage(imageName, category); err != nil {
+			stats.failed++
 			log.Errorf("Error scanning %s: %v", imageName, err)
 		}
 	}
-
-	return nil
 }
 
 func (p *Pipeline) scanSingleImage(imageName string, category string) error {

--- a/pkg/usecase/pipeline.go
+++ b/pkg/usecase/pipeline.go
@@ -85,6 +85,18 @@ func (s *scanStats) result() error {
 	return nil
 }
 
+// record counts a real scan attempt. Images skipped because they already
+// exist and --update-existing is unset are not attempts.
+func (s *scanStats) record(skipped bool, err error) {
+	if skipped {
+		return
+	}
+	s.attempted++
+	if err != nil {
+		s.failed++
+	}
+}
+
 // ScanAll loads repositories from config, discovers tags, and scans all images.
 // Individual image failures are logged and scanning continues. Returns an error
 // only when every scan attempt failed (total outage), so partial success still
@@ -101,9 +113,9 @@ func (p *Pipeline) ScanAll() error {
 		}
 
 		for _, img := range singleImages {
-			stats.attempted++
-			if err := p.scanSingleImage(img, group.Category); err != nil {
-				stats.failed++
+			skipped, err := p.scanSingleImage(img, group.Category)
+			stats.record(skipped, err)
+			if err != nil {
 				log.Errorf("Error scanning image %s: %v", img, err)
 			}
 		}
@@ -123,7 +135,8 @@ func (p *Pipeline) ScanAll() error {
 
 // ScanImage scans a single image by name.
 func (p *Pipeline) ScanImage(imageName string) error {
-	return p.scanSingleImage(imageName, "")
+	_, err := p.scanSingleImage(imageName, "")
+	return err
 }
 
 // GenerateReport generates both the markdown and JSON recommendations reports.
@@ -153,8 +166,7 @@ func (p *Pipeline) scanRepository(repo string, category string, stats *scanStats
 	tags, err := p.registry.GetTags(repo)
 	if err != nil {
 		// Count tag discovery failure as a single failed attempt for this repo.
-		stats.attempted++
-		stats.failed++
+		stats.record(false, err)
 		log.Errorf("Error scanning repository %s: getting tags: %v", repo, err)
 		return
 	}
@@ -167,30 +179,30 @@ func (p *Pipeline) scanRepository(repo string, category string, stats *scanStats
 	defaultRegistry := p.repoCfg.Defaults.Registry
 	for _, tag := range limited {
 		imageName := scanner.BuildFullImageName(defaultRegistry, repo, tag)
-		stats.attempted++
-		if err := p.scanSingleImage(imageName, category); err != nil {
-			stats.failed++
+		skipped, err := p.scanSingleImage(imageName, category)
+		stats.record(skipped, err)
+		if err != nil {
 			log.Errorf("Error scanning %s: %v", imageName, err)
 		}
 	}
 }
 
-func (p *Pipeline) scanSingleImage(imageName string, category string) error {
+func (p *Pipeline) scanSingleImage(imageName string, category string) (skipped bool, err error) {
 	if !p.config.UpdateExisting {
 		exists, err := p.repo.ImageExists(imageName)
 		if err != nil {
-			return fmt.Errorf("checking image existence: %w", err)
+			return false, fmt.Errorf("checking image existence: %w", err)
 		}
 
 		if exists {
 			log.Infof("Skipping existing image: %s", imageName)
-			return nil
+			return true, nil
 		}
 	}
 
 	analysis, err := p.analyzer.Analyze(imageName)
 	if err != nil {
-		return fmt.Errorf("analyzing %s: %w", imageName, err)
+		return false, fmt.Errorf("analyzing %s: %w", imageName, err)
 	}
 
 	if category == "base" && len(analysis.Image.Languages) == 0 {
@@ -204,12 +216,12 @@ func (p *Pipeline) scanSingleImage(imageName string, category string) error {
 	}
 
 	if err := p.repo.InsertImage(&analysis.Image); err != nil {
-		return fmt.Errorf("inserting %s: %w", imageName, err)
+		return false, fmt.Errorf("inserting %s: %w", imageName, err)
 	}
 
 	log.Infof("Successfully scanned and stored: %s", imageName)
 
-	return nil
+	return false, nil
 }
 
 // LoadRepositoryConfig reads the JSON config from the config directory.

--- a/pkg/usecase/pipeline_test.go
+++ b/pkg/usecase/pipeline_test.go
@@ -1,0 +1,59 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package usecase
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanStatsResult(t *testing.T) {
+	tests := []struct {
+		name      string
+		attempted int
+		failed    int
+		wantErr   bool
+		errSubstr string
+	}{
+		{"no attempts", 0, 0, false, ""},
+		{"all success", 5, 0, false, ""},
+		{"partial failure", 5, 2, false, ""},
+		{"total failure", 3, 3, true, "all 3 scan operations failed"},
+		{"single total failure", 1, 1, true, "all 1 scan operations failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &scanStats{attempted: tt.attempted, failed: tt.failed}
+			err := s.result()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/usecase/pipeline_test.go
+++ b/pkg/usecase/pipeline_test.go
@@ -23,6 +23,7 @@
 package usecase
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,4 +57,25 @@ func TestScanStatsResult(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestScanStatsRecord_SkipsAreNotAttempts(t *testing.T) {
+	s := &scanStats{}
+
+	s.record(true, nil)
+	assert.Equal(t, 0, s.attempted)
+	assert.Equal(t, 0, s.failed)
+	assert.NoError(t, s.result())
+
+	// One skipped image plus every real scan failing is a total outage.
+	s.record(false, errors.New("pull failed"))
+	s.record(true, nil)
+	s.record(false, errors.New("analyze failed"))
+	assert.Equal(t, 2, s.attempted)
+	assert.Equal(t, 2, s.failed)
+	require.Error(t, s.result())
+	assert.Contains(t, s.result().Error(), "all 2 scan operations failed")
+
+	s.record(false, nil)
+	assert.NoError(t, s.result(), "a real success after failures is partial, not total")
 }

--- a/pkg/usecase/pipeline_test.go
+++ b/pkg/usecase/pipeline_test.go
@@ -23,11 +23,16 @@
 package usecase
 
 import (
+	"database/sql"
 	"errors"
 	"testing"
 
+	"github.com/microsoft/sbi/pkg/domain"
+	"github.com/microsoft/sbi/pkg/infrastructure/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestScanStatsResult(t *testing.T) {
@@ -78,4 +83,209 @@ func TestScanStatsRecord_SkipsAreNotAttempts(t *testing.T) {
 
 	s.record(false, nil)
 	assert.NoError(t, s.result(), "a real success after failures is partial, not total")
+}
+
+func TestScanStatsRecord_SkipWithErrorCountsAsFailure(t *testing.T) {
+	s := &scanStats{}
+	s.record(true, errors.New("exists check failed"))
+	assert.Equal(t, 1, s.attempted)
+	assert.Equal(t, 1, s.failed)
+	require.Error(t, s.result())
+}
+
+type stubRegistry struct {
+	tags map[string][]string
+	errs map[string]error
+}
+
+func (s *stubRegistry) GetTags(repo string) ([]string, error) {
+	if err, ok := s.errs[repo]; ok {
+		return nil, err
+	}
+	return s.tags[repo], nil
+}
+
+type stubAnalyzer struct {
+	fail map[string]error
+}
+
+func (s *stubAnalyzer) Analyze(imageName string) (*domain.ImageAnalysis, error) {
+	if err, ok := s.fail[imageName]; ok {
+		return nil, err
+	}
+	return &domain.ImageAnalysis{
+		Image: domain.ImageRecord{Name: imageName},
+	}, nil
+}
+
+func setupPipelineDB(t *testing.T) *database.Repository {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec("PRAGMA foreign_keys=ON")
+	require.NoError(t, err)
+	require.NoError(t, database.CreateTables(db))
+
+	return database.NewRepository(db)
+}
+
+func testPipeline(repo *database.Repository, images []string, registry tagDiscoverer, analyzer imageAnalyzer) *Pipeline {
+	return &Pipeline{
+		config: domain.ScanConfig{MaxTagsPerRepo: 0},
+		repoCfg: domain.RepositoryConfig{
+			Defaults: domain.ConfigDefaults{Registry: "mcr.microsoft.com"},
+			Repositories: []domain.RepositoryGroup{{
+				Description: "test",
+				Images:      images,
+			}},
+		},
+		repo:     repo,
+		analyzer: analyzer,
+		registry: registry,
+	}
+}
+
+func TestScanAll_AllScansFail(t *testing.T) {
+	repo := setupPipelineDB(t)
+	p := testPipeline(repo, []string{"azurelinux/base/python:3.12"},
+		&stubRegistry{},
+		&stubAnalyzer{fail: map[string]error{"azurelinux/base/python:3.12": errors.New("pull failed")}},
+	)
+
+	err := p.ScanAll()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all 1 scan operations failed")
+}
+
+func TestScanAll_PartialFailureSucceeds(t *testing.T) {
+	repo := setupPipelineDB(t)
+	p := testPipeline(repo, []string{"good:1.0", "bad:1.0"},
+		&stubRegistry{},
+		&stubAnalyzer{fail: map[string]error{"bad:1.0": errors.New("analyze failed")}},
+	)
+
+	require.NoError(t, p.ScanAll())
+}
+
+func TestScanAll_SkipDoesNotMaskTotalFailure(t *testing.T) {
+	repo := setupPipelineDB(t)
+	require.NoError(t, repo.InsertImage(&domain.ImageRecord{Name: "already:1.0"}))
+
+	p := testPipeline(repo, []string{"already:1.0", "new:1.0"},
+		&stubRegistry{},
+		&stubAnalyzer{fail: map[string]error{"new:1.0": errors.New("pull failed")}},
+	)
+
+	err := p.ScanAll()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all 1 scan operations failed")
+}
+
+func TestScanAll_AllSkippedIsNotAnError(t *testing.T) {
+	repo := setupPipelineDB(t)
+	require.NoError(t, repo.InsertImage(&domain.ImageRecord{Name: "already:1.0"}))
+
+	p := testPipeline(repo, []string{"already:1.0"},
+		&stubRegistry{},
+		&stubAnalyzer{fail: map[string]error{"already:1.0": errors.New("should not be called")}},
+	)
+
+	require.NoError(t, p.ScanAll())
+}
+
+func TestScanAll_TagDiscoveryFailure(t *testing.T) {
+	repo := setupPipelineDB(t)
+	p := testPipeline(repo, []string{"azurelinux/base/python"},
+		&stubRegistry{errs: map[string]error{"azurelinux/base/python": errors.New("404")}},
+		&stubAnalyzer{},
+	)
+
+	err := p.ScanAll()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all 1 scan operations failed")
+}
+
+func TestScanAll_RepositoryTagsAllFail(t *testing.T) {
+	repo := setupPipelineDB(t)
+	reg := &stubRegistry{tags: map[string][]string{
+		"azurelinux/base/python": {"3.12", "3.11"},
+	}}
+	az := &stubAnalyzer{fail: map[string]error{
+		"mcr.microsoft.com/azurelinux/base/python:3.12": errors.New("fail 3.12"),
+		"mcr.microsoft.com/azurelinux/base/python:3.11": errors.New("fail 3.11"),
+	}}
+	p := testPipeline(repo, []string{"azurelinux/base/python"}, reg, az)
+
+	err := p.ScanAll()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all 2 scan operations failed")
+}
+
+func TestScanAll_RepositoryPartialSuccess(t *testing.T) {
+	repo := setupPipelineDB(t)
+	reg := &stubRegistry{tags: map[string][]string{
+		"azurelinux/base/python": {"3.12", "3.11"},
+	}}
+	az := &stubAnalyzer{fail: map[string]error{
+		"mcr.microsoft.com/azurelinux/base/python:3.11": errors.New("fail 3.11"),
+	}}
+	p := testPipeline(repo, []string{"azurelinux/base/python"}, reg, az)
+
+	require.NoError(t, p.ScanAll())
+}
+
+func TestScanAll_UpdateExistingRescansSkippedImage(t *testing.T) {
+	repo := setupPipelineDB(t)
+	require.NoError(t, repo.InsertImage(&domain.ImageRecord{Name: "already:1.0"}))
+
+	called := 0
+	az := &countingAnalyzer{fn: func(name string) (*domain.ImageAnalysis, error) {
+		called++
+		return &domain.ImageAnalysis{Image: domain.ImageRecord{Name: name}}, nil
+	}}
+	p := testPipeline(repo, []string{"already:1.0"}, &stubRegistry{}, az)
+	p.config.UpdateExisting = true
+
+	require.NoError(t, p.ScanAll())
+	assert.Equal(t, 1, called, "existing image must be rescanned when --update-existing is set")
+}
+
+type countingAnalyzer struct {
+	fn func(string) (*domain.ImageAnalysis, error)
+}
+
+func (c *countingAnalyzer) Analyze(imageName string) (*domain.ImageAnalysis, error) {
+	return c.fn(imageName)
+}
+
+func TestScanAll_EmptyConfigIsNotAnError(t *testing.T) {
+	repo := setupPipelineDB(t)
+	p := testPipeline(repo, nil, &stubRegistry{}, &stubAnalyzer{})
+	p.repoCfg.Repositories = nil
+
+	require.NoError(t, p.ScanAll())
+}
+
+func TestScanImage_ReturnsAnalyzeError(t *testing.T) {
+	repo := setupPipelineDB(t)
+	p := testPipeline(repo, nil, &stubRegistry{},
+		&stubAnalyzer{fail: map[string]error{"img:1.0": errors.New("boom")}},
+	)
+
+	err := p.ScanImage("img:1.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "analyzing img:1.0")
+}
+
+func TestScanImage_SkipExisting(t *testing.T) {
+	repo := setupPipelineDB(t)
+	require.NoError(t, repo.InsertImage(&domain.ImageRecord{Name: "img:1.0"}))
+	p := testPipeline(repo, nil, &stubRegistry{},
+		&stubAnalyzer{fail: map[string]error{"img:1.0": errors.New("should not analyze")}},
+	)
+
+	require.NoError(t, p.ScanImage("img:1.0"))
 }


### PR DESCRIPTION
## Description

`ScanAll` always returned `nil` even when every repository or image failed. A total outage still exited 0, and report generation (including the nightly commit) ran against a stale database.

This change tracks real scan outcomes and returns an error only when every attempt fails. Partial success still produces a report from newly scanned images. Images skipped because they already exist (without `--update-existing`) are not counted as successful attempts.

## Related Issue

Fixes #77

## Changes

- Track attempt/failure counts across tag discovery and image scans
- Continue on partial failure (unchanged)
- Return an error only when **all** real scan attempts fail
- Do not count skipped existing images as attempts
- Log a summary on partial failure
- Unit tests for `scanStats` and `ScanAll` outcomes (including skip vs. failure)

## Checklist

- [x] `task lint` passes locally
- [x] `task test` passes locally
- [x] Documentation updated (if applicable)

---

### Stacking

Independent of the Trivy/registry stacks — can merge in any order relative to them.
