### PR TITLE
fix: harden registry parsing (digests, ports, tag pagination)

### DIFF
--- a/pkg/infrastructure/scanner/analyzer_test.go
+++ b/pkg/infrastructure/scanner/analyzer_test.go
@@ -195,6 +195,11 @@ func TestExtractRegistryAndRepo(t *testing.T) {
 		{"Docker Hub", "docker.io/library/python:3.12-slim", "docker.io", "library/python", "3.12-slim"},
 		{"Short MCR", "azurelinux/base/python:3.12", "mcr.microsoft.com", "azurelinux/base/python", "3.12"},
 		{"No tag", "mcr.microsoft.com/azurelinux/base/python", "mcr.microsoft.com", "azurelinux/base/python", ""},
+		{"Tag with digest", "mcr.microsoft.com/dotnet/aspnet:8.0@sha256:abcdef", "mcr.microsoft.com", "dotnet/aspnet", "8.0"},
+		{"Digest only", "mcr.microsoft.com/dotnet/aspnet@sha256:abcdef", "mcr.microsoft.com", "dotnet/aspnet", ""},
+		{"Registry with port", "localhost:5000/myrepo:1.0", "localhost:5000", "myrepo", "1.0"},
+		{"Localhost no port", "localhost/myrepo:1.0", "localhost", "myrepo", "1.0"},
+		{"Nested path with digest", "mcr.microsoft.com/azurelinux/base/python:3.12-nonroot@sha256:deadbeef", "mcr.microsoft.com", "azurelinux/base/python", "3.12-nonroot"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/infrastructure/scanner/registry.go
+++ b/pkg/infrastructure/scanner/registry.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -34,6 +35,9 @@ import (
 	"github.com/microsoft/sbi/pkg/domain"
 	log "github.com/sirupsen/logrus"
 )
+
+// tagsPageSize is the per-request page size for registry tags/list pagination.
+const tagsPageSize = 100
 
 // DefaultTagFilter returns the default tag filter configuration.
 func DefaultTagFilter() domain.TagFilterConfig {
@@ -63,27 +67,83 @@ func NewRegistryScanner(defaultRegistry string) *RegistryScanner {
 	}
 }
 
-// GetTags fetches available tags for an MCR repository.
+// GetTags fetches available tags for a repository, following Registry API
+// pagination via the Link response header (rel="next").
 func (s *RegistryScanner) GetTags(repo string) ([]string, error) {
-	url := fmt.Sprintf("%s/v2/%s/tags/list", s.registryURL, repo)
-	log.Debugf("Fetching tags from: %s", url)
+	next := fmt.Sprintf("%s/v2/%s/tags/list?n=%d", s.registryURL, repo, tagsPageSize)
+	var all []string
 
-	resp, err := s.client.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("fetching tags for %s: %w", repo, err)
+	for next != "" {
+		log.Debugf("Fetching tags from: %s", next)
+
+		req, err := http.NewRequest(http.MethodGet, next, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating tags request for %s: %w", repo, err)
+		}
+
+		resp, err := s.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetching tags for %s: %w", repo, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, repo)
+		}
+
+		var tagsResp domain.TagsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&tagsResp); err != nil {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("decoding tags response: %w", err)
+		}
+		_ = resp.Body.Close()
+
+		all = append(all, tagsResp.Tags...)
+
+		base, err := url.Parse(next)
+		if err != nil {
+			return nil, fmt.Errorf("parsing tags URL for %s: %w", repo, err)
+		}
+		next = nextPageFromLink(base, resp.Header.Get("Link"))
 	}
-	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, repo)
+	return all, nil
+}
+
+// nextPageFromLink returns the absolute URL for rel="next" from an RFC 5988
+// Link header, or "" when there is no next page.
+func nextPageFromLink(base *url.URL, linkHeader string) string {
+	if linkHeader == "" || base == nil {
+		return ""
 	}
 
-	var tagsResp domain.TagsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tagsResp); err != nil {
-		return nil, fmt.Errorf("decoding tags response: %w", err)
+	for _, part := range strings.Split(linkHeader, ",") {
+		part = strings.TrimSpace(part)
+		lower := strings.ToLower(part)
+		// Accept rel="next" / rel=next / rel='next'
+		if !strings.Contains(lower, `rel="next"`) &&
+			!strings.Contains(lower, `rel='next'`) &&
+			!strings.Contains(lower, `rel=next`) {
+			continue
+		}
+
+		start := strings.Index(part, "<")
+		end := strings.Index(part, ">")
+		if start < 0 || end <= start {
+			continue
+		}
+
+		ref := strings.TrimSpace(part[start+1 : end])
+		resolved, err := base.Parse(ref)
+		if err != nil {
+			log.Warnf("Invalid pagination Link URL %q: %v", ref, err)
+			return ""
+		}
+
+		return resolved.String()
 	}
 
-	return tagsResp.Tags, nil
+	return ""
 }
 
 // FilterTags removes pre-release, arch-specific, and unwanted tags based on the provided config.

--- a/pkg/infrastructure/scanner/registry.go
+++ b/pkg/infrastructure/scanner/registry.go
@@ -296,24 +296,42 @@ func BuildFullImageName(defaultRegistry, repo, tag string) string {
 }
 
 // ExtractRegistryAndRepo splits a full image name into registry, repository, and tag.
+// Digest suffixes (@sha256:...) are stripped before parsing. Tags are taken from the
+// last ":" after the last "/", so host:port registries (e.g. localhost:5000) work.
 func ExtractRegistryAndRepo(imageName string) (registry, repository, tag string) {
-	// Split off the tag
-	parts := strings.SplitN(imageName, ":", 2)
-	nameWithoutTag := parts[0]
-	if len(parts) == 2 {
-		tag = parts[1]
+	name := imageName
+
+	// Strip @digest first — digests contain ":" (e.g. sha256:abc) and must not
+	// be mistaken for tags.
+	if at := strings.Index(name, "@"); at >= 0 {
+		name = name[:at]
 	}
 
-	// Split into registry and repository
+	// Tag separator is the last ":" after the last "/".
+	lastSlash := strings.LastIndex(name, "/")
+	lastColon := strings.LastIndex(name, ":")
+	nameWithoutTag := name
+	if lastColon > lastSlash {
+		tag = name[lastColon+1:]
+		nameWithoutTag = name[:lastColon]
+	}
+
+	// Registry is the first path segment when it looks like a host.
 	segments := strings.SplitN(nameWithoutTag, "/", 2)
-	if len(segments) == 2 && strings.Contains(segments[0], ".") {
+	if len(segments) == 2 && looksLikeRegistryHost(segments[0]) {
 		registry = segments[0]
 		repository = segments[1]
 	} else {
-		// Default to MCR
+		// Default to MCR for short names like "azurelinux/base/python:3.12"
 		registry = "mcr.microsoft.com"
 		repository = nameWithoutTag
 	}
 
 	return registry, repository, tag
+}
+
+// looksLikeRegistryHost reports whether s is a registry host (domain, host:port,
+// or localhost) rather than a repository path segment.
+func looksLikeRegistryHost(s string) bool {
+	return strings.Contains(s, ".") || strings.Contains(s, ":") || strings.EqualFold(s, "localhost")
 }

--- a/pkg/infrastructure/scanner/registry.go
+++ b/pkg/infrastructure/scanner/registry.go
@@ -39,6 +39,10 @@ import (
 // tagsPageSize is the per-request page size for registry tags/list pagination.
 const tagsPageSize = 100
 
+// maxTagPages caps GetTags pagination so a cyclic or unbounded Link header
+// cannot loop forever. The HTTP client timeout applies per request only.
+var maxTagPages = 100
+
 // DefaultTagFilter returns the default tag filter configuration.
 func DefaultTagFilter() domain.TagFilterConfig {
 	return domain.TagFilterConfig{
@@ -72,46 +76,64 @@ func NewRegistryScanner(defaultRegistry string) *RegistryScanner {
 func (s *RegistryScanner) GetTags(repo string) ([]string, error) {
 	next := fmt.Sprintf("%s/v2/%s/tags/list?n=%d", s.registryURL, repo, tagsPageSize)
 	var all []string
+	seen := make(map[string]struct{})
 
-	for next != "" {
-		log.Debugf("Fetching tags from: %s", next)
+	for page := 0; next != ""; page++ {
+		if page >= maxTagPages {
+			return nil, fmt.Errorf("tag pagination exceeded %d pages for %s", maxTagPages, repo)
+		}
+		if _, ok := seen[next]; ok {
+			log.Warnf("tag pagination cycle detected for %s at %s", repo, next)
+			break
+		}
+		seen[next] = struct{}{}
 
-		req, err := http.NewRequest(http.MethodGet, next, nil)
+		tags, linkHeader, err := s.fetchTagPage(next, repo)
 		if err != nil {
-			return nil, fmt.Errorf("creating tags request for %s: %w", repo, err)
+			return nil, err
 		}
-
-		resp, err := s.client.Do(req)
-		if err != nil {
-			return nil, fmt.Errorf("fetching tags for %s: %w", repo, err)
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			_ = resp.Body.Close()
-			return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, repo)
-		}
-
-		var tagsResp domain.TagsResponse
-		if err := json.NewDecoder(resp.Body).Decode(&tagsResp); err != nil {
-			_ = resp.Body.Close()
-			return nil, fmt.Errorf("decoding tags response: %w", err)
-		}
-		_ = resp.Body.Close()
-
-		all = append(all, tagsResp.Tags...)
+		all = append(all, tags...)
 
 		base, err := url.Parse(next)
 		if err != nil {
 			return nil, fmt.Errorf("parsing tags URL for %s: %w", repo, err)
 		}
-		next = nextPageFromLink(base, resp.Header.Get("Link"))
+		next = nextPageFromLink(base, linkHeader)
 	}
 
 	return all, nil
 }
 
+func (s *RegistryScanner) fetchTagPage(pageURL, repo string) ([]string, string, error) {
+	log.Debugf("Fetching tags from: %s", pageURL)
+
+	req, err := http.NewRequest(http.MethodGet, pageURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("creating tags request for %s: %w", repo, err)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("fetching tags for %s: %w", repo, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("unexpected status %d for %s", resp.StatusCode, repo)
+	}
+
+	var tagsResp domain.TagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tagsResp); err != nil {
+		return nil, "", fmt.Errorf("decoding tags response: %w", err)
+	}
+
+	return tagsResp.Tags, resp.Header.Get("Link"), nil
+}
+
 // nextPageFromLink returns the absolute URL for rel="next" from an RFC 5988
-// Link header, or "" when there is no next page.
+// Link header, or "" when there is no next page. Only the parameter list
+// after ">" is inspected, so a URL that happens to contain "rel=next" is
+// not treated as a next link.
 func nextPageFromLink(base *url.URL, linkHeader string) string {
 	if linkHeader == "" || base == nil {
 		return ""
@@ -119,17 +141,12 @@ func nextPageFromLink(base *url.URL, linkHeader string) string {
 
 	for _, part := range strings.Split(linkHeader, ",") {
 		part = strings.TrimSpace(part)
-		lower := strings.ToLower(part)
-		// Accept rel="next" / rel=next / rel='next'
-		if !strings.Contains(lower, `rel="next"`) &&
-			!strings.Contains(lower, `rel='next'`) &&
-			!strings.Contains(lower, `rel=next`) {
-			continue
-		}
-
 		start := strings.Index(part, "<")
 		end := strings.Index(part, ">")
 		if start < 0 || end <= start {
+			continue
+		}
+		if !linkRelIsNext(part[end+1:]) {
 			continue
 		}
 
@@ -144,6 +161,23 @@ func nextPageFromLink(base *url.URL, linkHeader string) string {
 	}
 
 	return ""
+}
+
+func linkRelIsNext(params string) bool {
+	for _, p := range strings.Split(params, ";") {
+		p = strings.TrimSpace(p)
+		key, val, ok := strings.Cut(p, "=")
+		if !ok || !strings.EqualFold(strings.TrimSpace(key), "rel") {
+			continue
+		}
+		val = strings.Trim(strings.TrimSpace(val), `"'`)
+		for _, token := range strings.Fields(val) {
+			if strings.EqualFold(token, "next") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // FilterTags removes pre-release, arch-specific, and unwanted tags based on the provided config.

--- a/pkg/infrastructure/scanner/registry_test.go
+++ b/pkg/infrastructure/scanner/registry_test.go
@@ -1,0 +1,122 @@
+//     MIT License
+//
+//     Copyright (c) Microsoft Corporation.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy
+//     of this software and associated documentation files (the "Software"), to deal
+//     in the Software without restriction, including without limitation the rights
+//     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//     copies of the Software, and to permit persons to whom the Software is
+//     furnished to do so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//     SOFTWARE
+
+package scanner
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNextPageFromLink(t *testing.T) {
+	base, err := url.Parse("https://mcr.microsoft.com/v2/repo/tags/list?n=100")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"empty", "", ""},
+		{"next relative", `</v2/repo/tags/list?n=100&last=abc>; rel="next"`, "https://mcr.microsoft.com/v2/repo/tags/list?n=100&last=abc"},
+		{"next absolute", `<https://mcr.microsoft.com/v2/repo/tags/list?n=100&last=z>; rel="next"`, "https://mcr.microsoft.com/v2/repo/tags/list?n=100&last=z"},
+		{"prev only", `</v2/repo/tags/list?n=100>; rel="prev"`, ""},
+		{"mixed", `</v2/repo/tags/list?n=100&last=a>; rel="prev", </v2/repo/tags/list?n=100&last=b>; rel="next"`, "https://mcr.microsoft.com/v2/repo/tags/list?n=100&last=b"},
+		{"rel without quotes", `</v2/repo/tags/list?n=100&last=c>; rel=next`, "https://mcr.microsoft.com/v2/repo/tags/list?n=100&last=c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, nextPageFromLink(base, tt.header))
+		})
+	}
+}
+
+func TestGetTags_FollowsPagination(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		assert.Equal(t, "/v2/azurelinux/base/python/tags/list", r.URL.Path)
+
+		switch r.URL.Query().Get("last") {
+		case "":
+			assert.Equal(t, "100", r.URL.Query().Get("n"))
+			w.Header().Set("Link", `</v2/azurelinux/base/python/tags/list?n=100&last=3.11>; rel="next"`)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name": "azurelinux/base/python",
+				"tags": []string{"3.12", "3.11"},
+			})
+		case "3.11":
+			// Final page — no Link header
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name": "azurelinux/base/python",
+				"tags": []string{"3.10", "3.9"},
+			})
+		default:
+			t.Fatalf("unexpected last=%q", r.URL.Query().Get("last"))
+		}
+	}))
+	defer srv.Close()
+
+	s := &RegistryScanner{
+		client:      srv.Client(),
+		registryURL: srv.URL,
+	}
+
+	tags, err := s.GetTags("azurelinux/base/python")
+	require.NoError(t, err)
+	assert.Equal(t, 2, hits, "should request both pages")
+	assert.Equal(t, []string{"3.12", "3.11", "3.10", "3.9"}, tags)
+}
+
+func TestGetTags_SinglePage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "repo",
+			"tags": []string{"1.0", "2.0"},
+		})
+	}))
+	defer srv.Close()
+
+	s := &RegistryScanner{client: srv.Client(), registryURL: srv.URL}
+	tags, err := s.GetTags("repo")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"1.0", "2.0"}, tags)
+}
+
+func TestGetTags_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	s := &RegistryScanner{client: srv.Client(), registryURL: srv.URL}
+	_, err := s.GetTags("missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}

--- a/pkg/infrastructure/scanner/registry_test.go
+++ b/pkg/infrastructure/scanner/registry_test.go
@@ -24,6 +24,7 @@ package scanner
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -48,6 +49,9 @@ func TestNextPageFromLink(t *testing.T) {
 		{"prev only", `</v2/repo/tags/list?n=100>; rel="prev"`, ""},
 		{"mixed", `</v2/repo/tags/list?n=100&last=a>; rel="prev", </v2/repo/tags/list?n=100&last=b>; rel="next"`, "https://mcr.microsoft.com/v2/repo/tags/list?n=100&last=b"},
 		{"rel without quotes", `</v2/repo/tags/list?n=100&last=c>; rel=next`, "https://mcr.microsoft.com/v2/repo/tags/list?n=100&last=c"},
+		{"rel single quotes", `</v2/repo/tags/list?n=100&last=d>; rel='next'`, "https://mcr.microsoft.com/v2/repo/tags/list?n=100&last=d"},
+		{"rel next prefetch", `</v2/repo/tags/list?n=100&last=e>; rel="next prefetch"`, "https://mcr.microsoft.com/v2/repo/tags/list?n=100&last=e"},
+		{"url contains rel=next", `</v2/repo/tags/list?rel=next>; rel="prev"`, ""},
 	}
 
 	for _, tt := range tests {
@@ -119,4 +123,47 @@ func TestGetTags_NonOKStatus(t *testing.T) {
 	_, err := s.GetTags("missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "404")
+}
+
+func TestGetTags_StopsOnCycle(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		// Self-referencing next link would loop forever without cycle detection.
+		w.Header().Set("Link", `</v2/repo/tags/list?n=100>; rel="next"`)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "repo",
+			"tags": []string{"1.0"},
+		})
+	}))
+	defer srv.Close()
+
+	s := &RegistryScanner{client: srv.Client(), registryURL: srv.URL}
+	tags, err := s.GetTags("repo")
+	require.NoError(t, err)
+	assert.Equal(t, 1, hits, "cyclic next link must not be followed")
+	assert.Equal(t, []string{"1.0"}, tags)
+}
+
+func TestGetTags_MaxPages(t *testing.T) {
+	orig := maxTagPages
+	maxTagPages = 3
+	t.Cleanup(func() { maxTagPages = orig })
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Link", fmt.Sprintf(`</v2/repo/tags/list?n=100&last=%d>; rel="next"`, hits))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "repo",
+			"tags": []string{fmt.Sprintf("t%d", hits)},
+		})
+	}))
+	defer srv.Close()
+
+	s := &RegistryScanner{client: srv.Client(), registryURL: srv.URL}
+	_, err := s.GetTags("repo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeded 3 pages")
+	assert.Equal(t, 3, hits)
 }


### PR DESCRIPTION
## Description

Consolidated registry fixes that both touch `pkg/infrastructure/scanner/registry.go`, stacked into one PR for a clean review/merge.

## Related Issues

Fixes #74  
Fixes #76  

## Changes

1. **`ExtractRegistryAndRepo`** — strip `@digest` first; last `:` after last `/` is the tag; support `host:port` / localhost (#74)
2. **`GetTags` pagination** — follow Registry API `Link: rel=next` with `n=100`; httptest multi-page tests (#76)

## Stack note

This replaces the overlapping single-file PRs #83 and #84 (closed in favor of this consolidated stack).

## Checklist

- [x] `go test ./...` passes locally
- [x] Documentation updated (if applicable)
- [x] Commits are logical and reviewable in order